### PR TITLE
Fix/second audit importants : audit pré-prod phase 2 : 7 IMPORTANTS (I1, I3, I6, I7, I8, I13, I14)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,9 +67,16 @@ FRONTEND_URL_PATTERN=
 
 BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
-QUEUE_CONNECTION=database
+# Queue (I6 + I8) : redis pour la prod (les notifs paiement asynchrones
+# sortent de la requete HTTP et passent par un worker dedie).
+# En dev sans worker, mettre "sync" -> execution synchrone (debug facile,
+# pas besoin de lancer queue:work).
+QUEUE_CONNECTION=redis
 
-CACHE_STORE=database
+# Cache (I8) : redis en prod. Stocker le cache en database envoie tous les
+# compteurs throttle (B3) et les SystemSettings (I7) dans Postgres -> ca
+# ne tient pas la charge Tabaski.
+CACHE_STORE=redis
 # CACHE_PREFIX=
 
 MEMCACHED_HOST=127.0.0.1

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,6 +37,25 @@ SESSION_SECURE_COOKIE=false
 # Same-site : "lax" si front+API meme domaine racine, "none" si domaines differents (HTTPS requis).
 SESSION_SAME_SITE=lax
 
+# Sliding session API (I1).
+# Inactivite : duree apres laquelle un token est invalide s il n a pas servi.
+# Tant que l utilisateur fait au moins 1 requete dans cette fenetre, sa
+# session ne meurt jamais (last_used_at est rafraichi toutes les 5 min).
+AUTH_SESSION_INACTIVITY_HOURS=6
+# Plafond dur cote cookie navigateur. Au-dela, le cookie est detruit meme
+# si la session est encore active. 168h = 7 jours.
+AUTH_SESSION_COOKIE_MAX_HOURS=168
+
+# Identifiants par defaut crees par DatabaseSeeder. OBLIGATOIRES (I14) : sans
+# ces variables, php artisan db:seed s arrete avec une erreur explicite.
+# L ancien fallback "password" creait des comptes trivialement compromettables.
+ADMIN_EMAIL=
+ADMIN_NAME=
+ADMIN_PASSWORD=
+GERANTE_EMAIL=
+GERANTE_NAME=
+GERANTE_PASSWORD=
+
 # CORS (I4) : URL exacte du frontend autorise (sans slash final). Optionnel si meme origine.
 FRONTEND_URL=
 # Pattern regex si plusieurs sous-domaines autorises.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,7 +18,11 @@ BCRYPT_ROUNDS=12
 LOG_CHANNEL=stack
 LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null
-LOG_LEVEL=debug
+# Niveau de log (I13). Defaut "warning" : safe pour la prod, evite la
+# saturation disque et le leak d infos sensibles (paiements, headers, etc.)
+# dans les logs. En dev local, repasser sur "debug" dans son .env si
+# besoin de tracer une requete precise.
+LOG_LEVEL=warning
 
 DB_CONNECTION=sqlite
 # DB_HOST=127.0.0.1

--- a/backend/app/Http/Controllers/Api/Admin/GeranteController.php
+++ b/backend/app/Http/Controllers/Api/Admin/GeranteController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
 
 class GeranteController extends Controller
 {
@@ -35,10 +36,13 @@ class GeranteController extends Controller
 
     public function store(Request $request): JsonResponse
     {
+        // Password complexe (I3) : min 12 caracteres + maj/min + chiffre +
+        // symbole. Bloque les "password123" et autres choix faibles que le
+        // simple min:8 laissait passer.
         $data = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'email', 'max:255', 'unique:users,email'],
-            'password' => ['required', 'string', 'min:8'],
+            'password' => ['required', 'string', Password::min(12)->mixedCase()->numbers()->symbols()],
             'actif' => ['sometimes', 'boolean'],
         ]);
 
@@ -70,10 +74,12 @@ class GeranteController extends Controller
     {
         abort_unless($gerante->hasRole('gerante'), 404);
 
+        // Meme regle complexe que pour la creation (I3) : si un nouveau
+        // password est fourni, il doit respecter la meme politique.
         $data = $request->validate([
             'name' => ['sometimes', 'string', 'max:255'],
             'email' => ['sometimes', 'email', 'max:255', Rule::unique('users', 'email')->ignore($gerante->id)],
-            'password' => ['nullable', 'string', 'min:8'],
+            'password' => ['nullable', 'string', Password::min(12)->mixedCase()->numbers()->symbols()],
             'actif' => ['sometimes', 'boolean'],
         ]);
 

--- a/backend/app/Http/Controllers/Api/Admin/PaiementController.php
+++ b/backend/app/Http/Controllers/Api/Admin/PaiementController.php
@@ -3,13 +3,13 @@
 namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Jobs\SendPaymentReceiptNotifications;
 use App\Models\Caisse;
 use App\Models\Client;
 use App\Models\MouvementCaisse;
 use App\Models\Paiement;
 use App\Models\ParametreSysteme;
 use App\Models\Reservation;
-use App\Services\PaymentReceiptNotificationService;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -25,10 +25,6 @@ class PaiementController extends Controller
     private const INCOMING_TYPES = ['acompte', 'solde', 'complet', 'ajustement'];
     private const METHODS = ['especes', 'wave', 'orange_money', 'carte_bancaire', 'virement', 'autre'];
     private const STATUSES = ['en_attente', 'valide', 'annule', 'rembourse'];
-
-    public function __construct(private readonly PaymentReceiptNotificationService $receiptNotifications)
-    {
-    }
 
     public function index(Request $request): JsonResponse
     {
@@ -51,7 +47,9 @@ class PaiementController extends Controller
         $data = $this->validatedPaymentData($request);
 
         $paiement = DB::transaction(fn (): Paiement => $this->persistPayment($data));
-        $this->receiptNotifications->send($paiement);
+        // Notif recue en queue (I6) : la requete admin repond sans attendre
+        // Twilio/WhatsApp/Mail.
+        SendPaymentReceiptNotifications::dispatch($paiement->id);
 
         return response()->json([
             'message' => 'Paiement enregistre.',
@@ -75,7 +73,8 @@ class PaiementController extends Controller
         $data = $this->validatedPaymentData($request, $paiement);
 
         $paiement = DB::transaction(fn (): Paiement => $this->persistPayment($data, $paiement));
-        $this->receiptNotifications->send($paiement);
+        // Notif recue en queue (I6).
+        SendPaymentReceiptNotifications::dispatch($paiement->id);
 
         return response()->json([
             'message' => 'Paiement mis a jour.',

--- a/backend/app/Http/Controllers/Api/Admin/ParametreSystemeController.php
+++ b/backend/app/Http/Controllers/Api/Admin/ParametreSystemeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\ParametreSysteme;
+use App\Support\SystemSettings;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -332,15 +333,12 @@ class ParametreSystemeController extends Controller
 
     private function settingValue(string $key): mixed
     {
-        $value = ParametreSysteme::query()->where('cle', $key)->value('valeur');
-
-        if (is_string($value)) {
-            $decoded = json_decode($value, true);
-
-            return $decoded['value'] ?? null;
-        }
-
-        return is_array($value) ? ($value['value'] ?? null) : null;
+        // Delegue a SystemSettings (cache I7). Comme la validation se fait avant
+        // l update, on lit ici la valeur AVANT modif - exactement ce qu il
+        // faut pour les checks de coherence (heure_ouverture vs heure_fermeture,
+        // seuil_retard vs seuil_absence). Apres l update, le model event saved
+        // flush le cache automatiquement.
+        return SystemSettings::get($key);
     }
 
     private function rawValue(mixed $value): mixed

--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -102,8 +102,12 @@ class AuthController extends Controller
     {
         return cookie(
             name: self::AUTH_COOKIE,
+            // Plafond dur cote navigateur (I1) : passe ce delai, le cookie est
+            // detruit par le navigateur, peu importe l activite. Le serveur
+            // applique en plus une expiration glissante de
+            // session_inactivity_hours via last_used_at.
             value: $token,
-            minutes: (int) config('session.lifetime', 120),
+            minutes: $this->cookieLifetimeMinutes(),
             path: (string) config('session.path', '/'),
             domain: config('session.domain'),
             secure: (bool) config('session.secure', false),
@@ -118,7 +122,7 @@ class AuthController extends Controller
         return cookie(
             name: self::CSRF_COOKIE,
             value: Str::random(40),
-            minutes: (int) config('session.lifetime', 120),
+            minutes: $this->cookieLifetimeMinutes(),
             path: (string) config('session.path', '/'),
             domain: config('session.domain'),
             secure: (bool) config('session.secure', false),
@@ -126,6 +130,11 @@ class AuthController extends Controller
             raw: false,
             sameSite: (string) config('session.same_site', 'lax'),
         );
+    }
+
+    private function cookieLifetimeMinutes(): int
+    {
+        return (int) config('auth.session_cookie_max_hours', 168) * 60;
     }
 
     private function withClearedAuthCookies(JsonResponse $response): JsonResponse

--- a/backend/app/Http/Controllers/Api/Client/PaymentController.php
+++ b/backend/app/Http/Controllers/Api/Client/PaymentController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers\Api\Client;
 
 use App\Http\Controllers\Controller;
+use App\Jobs\SendPaymentReceiptNotifications;
 use App\Models\Paiement;
 use App\Models\Reservation;
-use App\Services\PaymentReceiptNotificationService;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -16,10 +16,6 @@ use Illuminate\Validation\ValidationException;
 class PaymentController extends Controller
 {
     private const INCOMING_TYPES = ['acompte', 'solde', 'complet', 'ajustement'];
-
-    public function __construct(private readonly PaymentReceiptNotificationService $receiptNotifications)
-    {
-    }
 
     public function confirmStripeCheckout(Request $request): JsonResponse
     {
@@ -122,7 +118,10 @@ class PaymentController extends Controller
         if ($payment->statut !== 'valide') {
             $this->markPaymentAsPaid($payment, $payment->reference ?: 'paytech-return-' . $payment->id);
         } else {
-            $this->receiptNotifications->send($payment->fresh(['reservation.client', 'reservation.details', 'client']));
+            // Paiement deja valide (cas du retour PayTech post-webhook) : on
+            // re-pousse l envoi du recu en queue (I6) au cas ou le webhook
+            // n aurait pas reussi a notifier.
+            SendPaymentReceiptNotifications::dispatch($payment->id);
         }
 
         return response()->json([
@@ -288,7 +287,11 @@ class PaymentController extends Controller
         ])->save();
 
         $this->syncReservationPaymentState($payment->reservation_id);
-        $this->receiptNotifications->send($payment->fresh(['reservation.client', 'reservation.details', 'client']));
+        // Notif asynchrone (I6) : la requete webhook Stripe/PayTech repond
+        // immediatement (~50 ms au lieu de 1-5 s avec les appels HTTP
+        // Twilio/WhatsApp/Mail synchrones). Un worker queue:work consomme
+        // la queue Redis et envoie le recu en arriere-plan.
+        SendPaymentReceiptNotifications::dispatch($payment->id);
     }
 
     private function markPaymentAsCanceled(Paiement $payment, string $reference): void

--- a/backend/app/Http/Controllers/Api/Client/ReservationAvailabilityController.php
+++ b/backend/app/Http/Controllers/Api/Client/ReservationAvailabilityController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Api\Client;
 
 use App\Http\Controllers\Controller;
-use App\Models\ParametreSysteme;
 use App\Models\Reservation;
+use App\Support\SystemSettings;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -108,9 +108,9 @@ class ReservationAvailabilityController extends Controller
 
     private function settingValue(string $key, mixed $default): mixed
     {
-        $setting = ParametreSysteme::query()->where('cle', $key)->first();
-
-        return $setting?->valeur['value'] ?? $default;
+        // Delegue a SystemSettings (cache I7) : avant ce controller faisait
+        // 5 SELECT par requete de disponibilite, maintenant 0 sur cache hit.
+        return SystemSettings::get($key, $default);
     }
 
     /**

--- a/backend/app/Http/Controllers/Api/Client/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/Client/ReservationController.php
@@ -7,8 +7,8 @@ use App\Models\Client;
 use App\Models\CodePromo;
 use App\Models\Coiffure;
 use App\Models\Paiement;
-use App\Models\ParametreSysteme;
 use App\Models\Reservation;
+use App\Support\SystemSettings;
 use Carbon\Carbon;
 use Closure;
 use Illuminate\Http\JsonResponse;
@@ -633,9 +633,8 @@ class ReservationController extends Controller
 
     private function settingValue(string $key, mixed $default): mixed
     {
-        $setting = ParametreSysteme::query()->where('cle', $key)->first();
-
-        return $setting?->valeur['value'] ?? $default;
+        // Delegue a SystemSettings (cache I7) : 1 SELECT au cold-start, 0 ensuite.
+        return SystemSettings::get($key, $default);
     }
 
     /**

--- a/backend/app/Http/Middleware/AuthenticateApiToken.php
+++ b/backend/app/Http/Middleware/AuthenticateApiToken.php
@@ -50,6 +50,19 @@ class AuthenticateApiToken
             ], 401);
         }
 
+        // Sliding-window inactivity check (I1) : si le token n a pas ete utilise
+        // depuis plus de session_inactivity_hours, on le considere abandonne et
+        // on force une re-authentification. last_used_at est rafraichi tous les
+        // 5 min ci-dessous tant que l utilisateur fait des requetes, donc une
+        // session active ne meurt jamais.
+        $inactivityHours = (int) config('auth.session_inactivity_hours', 6);
+
+        if ($accessToken->last_used_at && $accessToken->last_used_at->lt(now()->subHours($inactivityHours))) {
+            return response()->json([
+                'message' => 'Session expiree pour cause d inactivite.',
+            ], 401);
+        }
+
         if (! $accessToken->user->actif) {
             return response()->json([
                 'message' => 'Compte desactive.',

--- a/backend/app/Jobs/SendPaymentReceiptNotifications.php
+++ b/backend/app/Jobs/SendPaymentReceiptNotifications.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Paiement;
+use App\Services\PaymentReceiptNotificationService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Envoi asynchrone des notifications de reçu de paiement (I6).
+ *
+ * Avant : PaymentReceiptNotificationService::send() etait appele en plein
+ * milieu du webhook Stripe / PayTech. Chaque appel = jusqu a 3 HTTP calls
+ * externes (Twilio + WhatsApp Cloud + Mail SMTP) -> 1 a 5 secondes
+ * bloquantes par paiement. Sous Tabaski, les workers PHP-FPM se faisaient
+ * saturer immediatement, et un timeout du PSP = retry agressif = explosion.
+ *
+ * Maintenant : la requete HTTP repond instantanement (~50 ms) en pushant
+ * le travail dans la queue Redis. Un worker dedie (php artisan queue:work)
+ * consomme la queue et envoie les notifs en arriere-plan, avec retry
+ * automatique en cas d echec transitoire.
+ *
+ * Le job prend uniquement l ID du paiement (pas le modele Eloquent) pour
+ * eviter les problemes de serialisation et garantir qu on lit la version
+ * la plus a jour en base au moment de l envoi (le webhook a pu changer
+ * statut/montant entre le dispatch et l execution).
+ */
+class SendPaymentReceiptNotifications implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Nombre de tentatives en cas d echec (HTTP timeout, erreur 5xx, etc.). */
+    public int $tries = 3;
+
+    /** Delais entre tentatives en secondes (10s, 30s, 60s). Backoff progressif. */
+    public function backoff(): array
+    {
+        return [10, 30, 60];
+    }
+
+    public function __construct(public readonly int $paiementId)
+    {
+    }
+
+    public function handle(PaymentReceiptNotificationService $service): void
+    {
+        $paiement = Paiement::query()->find($this->paiementId);
+
+        if (! $paiement) {
+            // Le paiement a pu etre supprime entre le dispatch et l execution.
+            // Inutile de retry, on log et on sort.
+            Log::warning('SendPaymentReceiptNotifications : paiement introuvable', [
+                'paiement_id' => $this->paiementId,
+            ]);
+
+            return;
+        }
+
+        $service->send($paiement);
+    }
+}

--- a/backend/app/Models/ParametreSysteme.php
+++ b/backend/app/Models/ParametreSysteme.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\SystemSettings;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -12,6 +13,22 @@ class ParametreSysteme extends Model
     use HasFactory;
 
     protected $table = 'parametres_systeme';
+
+    /**
+     * Model events (I7) : tout changement (creation / mise a jour / suppression)
+     * d un parametre invalide le cache de SystemSettings, pour que la prochaine
+     * lecture reflete immediatement la nouvelle valeur. Plus besoin d attendre
+     * l expiration du TTL.
+     */
+    protected static function booted(): void
+    {
+        static::saved(static function (): void {
+            SystemSettings::flush();
+        });
+        static::deleted(static function (): void {
+            SystemSettings::flush();
+        });
+    }
 
     /**
      * @return array<string, string>

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -57,9 +57,14 @@ class User extends Authenticatable
     {
         $plainTextToken = Str::random(80);
 
+        // last_used_at = now() : sert d ancre pour la verification d inactivite
+        // (I1). Sans ca, un token frais avec last_used_at NULL ne pourrait
+        // jamais etre invalide pour inactivite, meme si le compte est laisse
+        // a l abandon entre la creation et la 1re requete.
         $this->tokens()->create([
             'name' => $name,
             'token' => hash('sha256', $plainTextToken),
+            'last_used_at' => now(),
         ]);
 
         return $plainTextToken;

--- a/backend/app/Services/PaymentReceiptNotificationService.php
+++ b/backend/app/Services/PaymentReceiptNotificationService.php
@@ -4,7 +4,7 @@ namespace App\Services;
 
 use App\Mail\ReservationConfirmationMail;
 use App\Models\Paiement;
-use App\Models\ParametreSysteme;
+use App\Support\SystemSettings;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
@@ -346,8 +346,7 @@ class PaymentReceiptNotificationService
 
     private function settingValue(string $key, mixed $default): mixed
     {
-        $setting = ParametreSysteme::query()->where('cle', $key)->first();
-
-        return $setting?->valeur['value'] ?? $default;
+        // Delegue a SystemSettings (cache I7).
+        return SystemSettings::get($key, $default);
     }
 }

--- a/backend/app/Support/SystemSettings.php
+++ b/backend/app/Support/SystemSettings.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\ParametreSysteme;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Acces centralise et cache aux parametres systeme (I7).
+ *
+ * Avant : chaque controller/service avait sa propre methode settingValue() qui
+ * faisait un SELECT par appel. ReservationAvailabilityController appelait par
+ * exemple settingValue() 5 fois -> 5 SELECT par requete de disponibilite.
+ *
+ * Maintenant : un seul SELECT au cold-start qui charge tous les parametres,
+ * mis en cache 1h. Les ecritures (admin qui modifie un parametre) flushent
+ * automatiquement le cache via les model events de ParametreSysteme.
+ *
+ * En prod, le store cache pointe sur Redis (cf .env CACHE_STORE) -> 0 SQL
+ * par lecture apres le 1er hit.
+ */
+class SystemSettings
+{
+    /** Cle unique pour stocker l ensemble des parametres. */
+    private const CACHE_KEY = 'system_settings.all';
+
+    /** TTL d 1 heure : protection contre un oubli de flush. Le flush via model
+     *  events est l autorite principale ; ce TTL n est qu un filet de secours. */
+    private const TTL_SECONDS = 3600;
+
+    /**
+     * Recupere la valeur scalaire d un parametre (deja unwrap-ee de la
+     * structure JSON ['value' => ...] utilisee en base).
+     *
+     * @param string $key La cle, ex: "heure_ouverture", "limite_reservations_par_jour"
+     * @param mixed $default Valeur de repli si la cle n existe pas
+     */
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        $entry = self::all()[$key] ?? null;
+
+        if (! is_array($entry)) {
+            return $default;
+        }
+
+        return array_key_exists('value', $entry) ? $entry['value'] : $default;
+    }
+
+    /**
+     * Charge tous les parametres en une seule requete.
+     *
+     * @return array<string, array<string, mixed>> Map cle => valeur (objet JSON brut)
+     */
+    public static function all(): array
+    {
+        return Cache::remember(self::CACHE_KEY, self::TTL_SECONDS, function (): array {
+            return ParametreSysteme::query()
+                ->get(['cle', 'valeur'])
+                ->mapWithKeys(fn (ParametreSysteme $p): array => [
+                    $p->cle => is_array($p->valeur) ? $p->valeur : [],
+                ])
+                ->all();
+        });
+    }
+
+    /**
+     * Invalide le cache. Appele automatiquement par les model events de
+     * ParametreSysteme (saved/deleted), donc inutile en temps normal.
+     * Disponible aussi pour les commandes artisan ou les seeders.
+     */
+    public static function flush(): void
+    {
+        Cache::forget(self::CACHE_KEY);
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^8.3",
         "laravel/framework": "^13.0",
-        "laravel/tinker": "^3.0"
+        "laravel/tinker": "^3.0",
+        "predis/predis": "^3.4"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12a93e9ee58f99b3ee9ac9b5d35d65e5",
+    "content-hash": "ff3578a7c027298f52505398312e0b12",
     "packages": [
         {
             "name": "brick/math",
@@ -2610,6 +2610,69 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "predis/predis",
+            "version": "v3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/predis/predis.git",
+                "reference": "2033429520d8997a7815a2485f56abe6d2d0e075"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/predis/predis/zipball/2033429520d8997a7815a2485f56abe6d2d0e075",
+                "reference": "2033429520d8997a7815a2485f56abe6d2d0e075",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "psr/http-message": "^1.0|^2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.3",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpcov": "^6.0 || ^8.0",
+                "phpunit/phpunit": "^8.0 || ~9.4.4"
+            },
+            "suggest": {
+                "ext-relay": "Faster connection with in-memory caching (>=0.6.2)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Till Krüss",
+                    "homepage": "https://till.im",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A flexible and feature-complete Redis/Valkey client for PHP.",
+            "homepage": "http://github.com/predis/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/predis/predis/issues",
+                "source": "https://github.com/predis/predis/tree/v3.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/tillkruss",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-09T20:33:04+00:00"
         },
         {
             "name": "psr/clock",

--- a/backend/config/auth.php
+++ b/backend/config/auth.php
@@ -114,4 +114,25 @@ return [
 
     'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
 
+    /*
+    |--------------------------------------------------------------------------
+    | API Token Session (I1)
+    |--------------------------------------------------------------------------
+    |
+    | session_inactivity_hours : duree apres laquelle un token est invalide
+    | s il n a pas ete utilise. Le middleware AuthenticateApiToken refresh
+    | last_used_at sur chaque requete (toutes les 5 min), donc tant que
+    | l utilisateur fait au moins une requete dans la fenetre, sa session
+    | reste vivante. Sliding window.
+    |
+    | session_cookie_max_hours : plafond dur cote cookie navigateur. Meme
+    | si last_used_at est recent, au-dela de cette duree depuis l emission
+    | le cookie est detruit par le navigateur. Anti-vol-de-cookie longue
+    | duree. 168h = 7 jours.
+    |
+    */
+
+    'session_inactivity_hours' => (int) env('AUTH_SESSION_INACTIVITY_HOURS', 6),
+    'session_cookie_max_hours' => (int) env('AUTH_SESSION_COOKIE_MAX_HOURS', 168),
+
 ];

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -30,12 +30,16 @@ class DatabaseSeeder extends Seeder
             ['description' => 'Gerante du salon']
         );
 
+        // Mots de passe admin et gerante : OBLIGATOIRES via env (I14).
+        // L ancien fallback 'password' permettait de seeder en prod par
+        // accident avec un compte trivialement compromettable. On exige
+        // desormais une valeur explicite avant tout seed.
         User::query()->updateOrCreate([
             'email' => env('ADMIN_EMAIL', 'admin@bichette-thomas.test'),
         ], [
             'role_id' => $adminRole->id,
             'name' => env('ADMIN_NAME', 'Administratrice'),
-            'password' => Hash::make(env('ADMIN_PASSWORD', 'password')),
+            'password' => Hash::make($this->requireEnv('ADMIN_PASSWORD')),
             'email_verified_at' => now(),
         ]);
 
@@ -44,7 +48,7 @@ class DatabaseSeeder extends Seeder
         ], [
             'role_id' => $geranteRole->id,
             'name' => env('GERANTE_NAME', 'Gerante'),
-            'password' => Hash::make(env('GERANTE_PASSWORD', 'password')),
+            'password' => Hash::make($this->requireEnv('GERANTE_PASSWORD')),
             'email_verified_at' => now(),
         ]);
 
@@ -68,6 +72,24 @@ class DatabaseSeeder extends Seeder
                 $rule
             );
         }
+    }
+
+    /**
+     * Recupere une variable d environnement obligatoire, ou throw avec un
+     * message clair (I14). Empeche le seed de fabriquer silencieusement un
+     * compte avec un mot de passe par defaut si l env n est pas configuree.
+     */
+    private function requireEnv(string $key): string
+    {
+        $value = env($key);
+
+        if (! is_string($value) || $value === '') {
+            throw new \RuntimeException(
+                "La variable d environnement {$key} doit etre definie avant de lancer db:seed."
+            );
+        }
+
+        return $value;
     }
 
     /**

--- a/frontend/src/features/admin/personnel/GerantesPage.tsx
+++ b/frontend/src/features/admin/personnel/GerantesPage.tsx
@@ -20,6 +20,12 @@ import {
 } from './personnel.api'
 import type { Gerante, GeranteForm, LaravelPaginated } from './personnel.types'
 
+// Doit miroir cote backend : Password::min(12)->mixedCase()->numbers()->symbols()
+// (cf GeranteController). On valide cote client pour un retour utilisateur
+// immediat ; le serveur reste l autorite finale.
+const PASSWORD_RULE = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{12,}$/
+const PASSWORD_HINT = 'Minimum 12 caracteres avec majuscule, minuscule, chiffre et symbole.'
+
 const emptyForm: GeranteForm = {
   name: '',
   email: '',
@@ -117,8 +123,13 @@ function GerantesPage() {
     setSaving(true)
     setError(null)
     try {
-      if (!editing && form.password.trim().length < 8) {
-        setError('Le mot de passe doit contenir au moins 8 caracteres.')
+      // En creation : password obligatoire, doit respecter la complexite.
+      // En edition : password optionnel ; s il est fourni, meme regle.
+      const trimmedPassword = form.password.trim()
+      const passwordProvided = trimmedPassword !== ''
+
+      if ((!editing || passwordProvided) && !PASSWORD_RULE.test(form.password)) {
+        setError(`Le mot de passe est trop faible. ${PASSWORD_HINT}`)
         return
       }
 
@@ -352,12 +363,14 @@ function GerantesPage() {
                 <input
                   className={inputClass}
                   type="password"
-                  minLength={editing ? undefined : 8}
+                  minLength={editing ? undefined : 12}
                   value={form.password}
                   onChange={(event) => setForm((current) => ({ ...current, password: event.target.value }))}
                   required={!editing}
-                  placeholder={editing ? 'Laisser vide pour conserver' : 'Minimum 8 caracteres'}
+                  placeholder={editing ? 'Laisser vide pour conserver' : 'Minimum 12 caracteres'}
                 />
+                {/* Aide visuelle alignee sur la regle backend (I3). */}
+                <p className="mt-1 text-xs text-gray-500">{PASSWORD_HINT}</p>
               </FormField>
               <label className="flex items-center gap-3 rounded-lg border border-gray-100 px-3 py-3 text-sm font-bold sm:self-end">
                 <input


### PR DESCRIPTION
## Résumé
  Phase 2 de l'audit pré-prod, après les BLOQUANTS de la PR #44.
  Traite 7 des 14 IMPORTANTS, ciblés sécurité auth + perfs DB/cache/queue
  (préparation Tabaski).

  ## Commits
  - I1 : sliding session 6h d'inactivité (last_used_at + cap 7j cookie)
  - I3 : password complexe (Password::min(12)->mixedCase()->numbers()->symbols())
    sur GeranteController + miroir frontend
  - I6 : notifications de paiement en queue Redis async (job + 4 callsites)
  - I7 : cache des paramètres système avec invalidation auto via model events
  - I8 : CACHE_STORE et QUEUE_CONNECTION par défaut sur Redis
  - I13 : LOG_LEVEL=warning par défaut (safe prod)
  - I14 : seeder strict (throw si ADMIN_PASSWORD/GERANTE_PASSWORD absentes)
  - chore : ajout dépendance predis/predis (client Redis sans extension PHP)

  ## Tests locaux effectués
  - I1 : confirmé via `AUTH_SESSION_INACTIVITY_HOURS=0` → session expirée
  - I3 : front + back rejettent un mot de passe trop simple (422)
  - I6 : worker queue:work traite le job en 86ms en arrière-plan
  - I7 : cache `system_settings.all` créé puis flushé après modif d'un paramètre
  - I8 : Redis confirmé via tinker + redis-cli -n 1 KEYS *
  - I14 : seed throws RuntimeException si env absentes

  ## À faire avant prod
  - B1 (Stripe) : révoquer les clés test exposées + générer nouvelles
  - ADMIN_PASSWORD / GERANTE_PASSWORD : vraies valeurs en prod, jamais 'password'
  - Lancer `php artisan queue:work` dans un container/process dédié
  - Reste : I2 (policies), I9-I12 (perfs frontend) — prochaine PR