### PR TITLE
Fix/third audit frontend perfs : audit pré-prod Phase 3 : 4 IMPORTANTS frontend perfs (I9, I10, I11, I12)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,36 @@
+import { lazy, Suspense, type ReactNode } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
-import type { ReactNode } from 'react'
+
+// Routes "publiques" (page client, login) : import direct - elles font partie
+// du parcours principal et le visiteur du catalogue les charge de toute facon.
 import LoginPage from './pages/LoginPage'
-import AdminDashboardPage from './features/admin/dashboard/AdminDashboardPage'
-import ClientsPage from './features/admin/clients/ClientsPage'
-import ReservationsPage from './features/admin/reservations/ReservationsPage'
-import PaymentsPage from './features/admin/payments/PaymentsPage'
-import ExpensesPage from './features/admin/expenses/ExpensesPage'
-import ReportsPage from './features/admin/reports/ReportsPage'
-import ReviewsPage from './features/admin/reviews/ReviewsPage'
-import CatalogueOverviewPage from './features/admin/catalogue/CatalogueOverviewPage'
-import CategoriesCoiffuresPage from './features/admin/catalogue/CategoriesCoiffuresPage'
-import CoiffuresPage from './features/admin/catalogue/CoiffuresPage'
-import OptionsCoiffuresPage from './features/admin/catalogue/OptionsCoiffuresPage'
-import VariantesCoiffuresPage from './features/admin/catalogue/VariantesCoiffuresPage'
-import PersonnelOverviewPage from './features/admin/personnel/PersonnelOverviewPage'
-import GerantesPage from './features/admin/personnel/GerantesPage'
-import CoiffeusesPage from './features/admin/personnel/CoiffeusesPage'
-import SettingsPage from './features/admin/settings/SettingsPage'
-import PromotionsPage from './features/admin/promotions/PromotionsPage'
-import RequireAuth from './features/auth/RequireAuth'
 import ClientHomePage from './features/client/ClientHomePage'
+import RequireAuth from './features/auth/RequireAuth'
+
+// Routes admin (I9) : code-split via React.lazy + Suspense.
+// Avant : toutes les pages admin (17 chunks ~200 kB gzippes au total) etaient
+// dans le bundle initial. Un visiteur du catalogue telechargeait inutilement
+// le code admin qu il ne verra jamais.
+// Maintenant : chaque page admin est un chunk separe, charge a la demande
+// quand l administratrice navigue dessus. Bundle initial client allege de
+// ~100-200 kB gzipped, premier rendu plus rapide (critique en mobile/3G).
+const AdminDashboardPage = lazy(() => import('./features/admin/dashboard/AdminDashboardPage'))
+const ClientsPage = lazy(() => import('./features/admin/clients/ClientsPage'))
+const ReservationsPage = lazy(() => import('./features/admin/reservations/ReservationsPage'))
+const PaymentsPage = lazy(() => import('./features/admin/payments/PaymentsPage'))
+const ExpensesPage = lazy(() => import('./features/admin/expenses/ExpensesPage'))
+const ReportsPage = lazy(() => import('./features/admin/reports/ReportsPage'))
+const ReviewsPage = lazy(() => import('./features/admin/reviews/ReviewsPage'))
+const CatalogueOverviewPage = lazy(() => import('./features/admin/catalogue/CatalogueOverviewPage'))
+const CategoriesCoiffuresPage = lazy(() => import('./features/admin/catalogue/CategoriesCoiffuresPage'))
+const CoiffuresPage = lazy(() => import('./features/admin/catalogue/CoiffuresPage'))
+const OptionsCoiffuresPage = lazy(() => import('./features/admin/catalogue/OptionsCoiffuresPage'))
+const VariantesCoiffuresPage = lazy(() => import('./features/admin/catalogue/VariantesCoiffuresPage'))
+const PersonnelOverviewPage = lazy(() => import('./features/admin/personnel/PersonnelOverviewPage'))
+const GerantesPage = lazy(() => import('./features/admin/personnel/GerantesPage'))
+const CoiffeusesPage = lazy(() => import('./features/admin/personnel/CoiffeusesPage'))
+const SettingsPage = lazy(() => import('./features/admin/settings/SettingsPage'))
+const PromotionsPage = lazy(() => import('./features/admin/promotions/PromotionsPage'))
 
 function ManagerDashboard() {
   return (
@@ -47,8 +58,25 @@ function NotFound() {
   )
 }
 
+// Fallback affiche pendant le chargement d un chunk admin paresseux.
+// Volontairement minimaliste : la page entiere n est pas encore montee, on
+// donne juste un retour visuel discret (3 ms a peine sur reseau rapide,
+// jusqu a quelques centaines de ms en 3G).
+function RouteSuspenseFallback() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#faf9fa]">
+      <div className="text-sm font-semibold text-gray-500">Chargement...</div>
+    </div>
+  )
+}
+
 function AdminRoute({ children }: { children: ReactNode }) {
-  return <RequireAuth role="admin">{children}</RequireAuth>
+  // Wrap dans Suspense pour gerer le chunk lazy en cours de chargement.
+  return (
+    <RequireAuth role="admin">
+      <Suspense fallback={<RouteSuspenseFallback />}>{children}</Suspense>
+    </RequireAuth>
+  )
 }
 
 function App() {
@@ -58,14 +86,7 @@ function App() {
       <Route path="/client" element={<ClientHomePage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />
-      <Route
-        path="/admin/dashboard"
-        element={
-          <AdminRoute>
-            <AdminDashboardPage />
-          </AdminRoute>
-        }
-      />
+      <Route path="/admin/dashboard" element={<AdminRoute><AdminDashboardPage /></AdminRoute>} />
       <Route path="/admin/clients" element={<AdminRoute><ClientsPage /></AdminRoute>} />
       <Route path="/admin/reservations" element={<AdminRoute><ReservationsPage /></AdminRoute>} />
       <Route path="/admin/paiements" element={<AdminRoute><PaymentsPage /></AdminRoute>} />

--- a/frontend/src/features/client/ClientHomePage.tsx
+++ b/frontend/src/features/client/ClientHomePage.tsx
@@ -8,7 +8,6 @@ import {
   Clock,
   CreditCard,
   Gift,
-  Heart,
   Home,
   Image as ImageIcon,
   Camera,
@@ -28,7 +27,7 @@ import {
   X,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
-import { type FormEvent, useEffect, useMemo, useState } from 'react'
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import heroImage from '../../assets/hero.jpg'
 import {
   confirmPaytechReturn,
@@ -39,6 +38,20 @@ import {
   getClientCatalogue,
   getClientCoiffureDetails,
 } from './client.api'
+import {
+  closedDaysLabel,
+  coiffureImage,
+  depositAmount,
+  discountAmount,
+  formatCurrency,
+  formatDuration,
+  formatShortDate,
+  isClosedDate,
+  promoText,
+  todayInput,
+} from './client.helpers'
+import { CoiffureCard } from './components/CoiffureCard'
+import { RatingStars } from './components/RatingStars'
 import type {
   ClientAvailability,
   ClientCatalogue,
@@ -49,7 +62,6 @@ import type {
   ClientPromotion,
   ClientReservation,
   ClientReservationPayload,
-  ClientSettings,
   ClientCoiffureReviewPayload,
 } from './client.types'
 
@@ -122,61 +134,10 @@ const emptyCategories: ClientCategory[] = []
 const emptyCoiffures: ClientCoiffure[] = []
 const emptyPromotions: ClientPromotion[] = []
 
-function toInputDate(date: Date) {
-  const normalized = new Date(date)
-  normalized.setMinutes(normalized.getMinutes() - normalized.getTimezoneOffset())
-
-  return normalized.toISOString().slice(0, 10)
-}
-
-function todayInput() {
-  return toInputDate(new Date())
-}
-
-const weekDays = [
-  'lundi',
-  'mardi',
-  'mercredi',
-  'jeudi',
-  'vendredi',
-  'samedi',
-  'dimanche',
-] as const
-
-const weekDayLabels: Record<(typeof weekDays)[number], string> = {
-  lundi: 'Lundi',
-  mardi: 'Mardi',
-  mercredi: 'Mercredi',
-  jeudi: 'Jeudi',
-  vendredi: 'Vendredi',
-  samedi: 'Samedi',
-  dimanche: 'Dimanche',
-}
-
-function dayKeyFromDate(dateString: string) {
-  const date = new Date(`${dateString}T00:00:00`)
-  const dayIndex = date.getDay()
-
-  return weekDays[(dayIndex + 6) % 7]
-}
-
-function isClosedDate(dateString: string, settings?: ClientSettings) {
-  if (!settings?.jours_fermeture || settings.jours_fermeture.length === 0) {
-    return false
-  }
-
-  const key = dayKeyFromDate(dateString)
-
-  return settings.jours_fermeture.includes(key)
-}
-
-function closedDaysLabel(days: string[]) {
-  if (!days || days.length === 0) {
-    return 'Ouvert toute la semaine'
-  }
-
-  return `Ferme: ${weekDays.filter((day) => days.includes(day)).map((day) => weekDayLabels[day]).join(', ')}`
-}
+// Les helpers de formatage / calcul / dates sont externalises dans
+// ./client.helpers.ts pour permettre le memo correct des sous-composants
+// (CoiffureCard, etc.). Les composants RatingStars et CoiffureCard sont
+// dans ./components/ et memoizes (I11).
 
 function createBookingForm(coiffure?: ClientCoiffure): BookingForm {
   return {
@@ -201,91 +162,6 @@ const emptyReviewForm = (): ReviewForm => ({
   note: 5,
   commentaire: '',
 })
-
-function formatCurrency(value: number | string, devise = 'FCFA') {
-  const amount = Number(value || 0)
-
-  return `${new Intl.NumberFormat('fr-FR').format(amount)} ${devise}`
-}
-
-function formatDuration(minutes: number) {
-  if (minutes < 60) {
-    return `${minutes} min`
-  }
-
-  const hours = Math.floor(minutes / 60)
-  const remaining = minutes % 60
-
-  return remaining > 0 ? `${hours}h ${remaining}min` : `${hours}h`
-}
-
-function formatShortDate(value?: string | null) {
-  if (!value) {
-    return '-'
-  }
-
-  const date = new Date(value)
-
-  if (Number.isNaN(date.getTime())) {
-    return value
-  }
-
-  return new Intl.DateTimeFormat('fr-FR', {
-    day: '2-digit',
-    month: 'short',
-  }).format(date)
-}
-
-function RatingStars({ value, size = 'sm' }: { value: number; size?: 'xs' | 'sm' }) {
-  const iconSize = size === 'xs' ? 'h-3.5 w-3.5' : 'h-4 w-4'
-
-  return (
-    <span className="inline-flex items-center gap-0.5 text-[#f59e0b]">
-      {Array.from({ length: 5 }, (_, index) => (
-        <Star
-          key={index}
-          className={`${iconSize} ${index < Math.round(value) ? 'fill-[#f59e0b]' : 'fill-none text-slate-300'}`}
-        />
-      ))}
-    </span>
-  )
-}
-
-function coiffureImage(coiffure: ClientCoiffure) {
-  return coiffure.image ?? coiffure.images[0]?.url ?? heroImage
-}
-
-function promoText(promo: ClientPromotion) {
-  if (promo.type_reduction === 'pourcentage') {
-    return `-${Number(promo.valeur)}%`
-  }
-
-  return `-${formatCurrency(promo.valeur)}`
-}
-
-function discountAmount(promo: ClientPromotion | null, total: number) {
-  if (!promo) {
-    return 0
-  }
-
-  if (promo.type_reduction === 'pourcentage') {
-    return Math.min(total, total * (Number(promo.valeur) / 100))
-  }
-
-  return Math.min(total, Number(promo.valeur))
-}
-
-function depositAmount(total: number, settings?: ClientSettings) {
-  if (!settings) {
-    return 0
-  }
-
-  if (Number(settings.pourcentage_acompte) > 0) {
-    return total * (Number(settings.pourcentage_acompte) / 100)
-  }
-
-  return Math.min(Number(settings.montant_acompte_defaut || 0), total)
-}
 
 function extractApiError(error: unknown) {
   if (axios.isAxiosError(error)) {
@@ -539,9 +415,15 @@ function ClientHomePage() {
     }))
   }
 
-  function toggleFavorite(id: number) {
-    setFavoriteIds((current) => (current.includes(id) ? current.filter((favoriteId) => favoriteId !== id) : [...current, id]))
-  }
+  // useCallback pour stabiliser les references entre re-renders et permettre
+  // au memo de CoiffureCard de fonctionner (sinon nouveau callback a chaque
+  // render -> memo casse -> 8 cartes re-rendent a chaque frappe). Pareil
+  // pour openDetails plus bas.
+  const toggleFavorite = useCallback((id: number) => {
+    setFavoriteIds((current) =>
+      current.includes(id) ? current.filter((favoriteId) => favoriteId !== id) : [...current, id],
+    )
+  }, [])
 
   function toggleOption(option: ClientCoiffureOption) {
     setBookingForm((current) => {
@@ -566,7 +448,10 @@ function ClientHomePage() {
     setAvailabilityLoading(false)
   }
 
-  async function openDetails(coiffure: ClientCoiffure) {
+  // useCallback : stabilise la reference pour que CoiffureCard memo bite.
+  // Toutes les valeurs capturees sont des setters (stables) ou des helpers
+  // au niveau module (stables) donc deps array vide suffit.
+  const openDetails = useCallback(async (coiffure: ClientCoiffure) => {
     setSelectedCoiffure(coiffure)
     setBookingForm(createBookingForm(coiffure))
     setSubmitState(null)
@@ -590,7 +475,7 @@ function ClientHomePage() {
     } finally {
       setModalLoading(false)
     }
-  }
+  }, [])
 
   async function handleReviewSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -862,36 +747,14 @@ function ClientHomePage() {
             ) : (
               <div className="mt-5 grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
                 {featuredCoiffures.map((coiffure) => (
-                  <article key={coiffure.id} className="group overflow-hidden rounded-3xl border border-slate-100 bg-white shadow-sm">
-                    <div className="relative aspect-[4/3] bg-rose-50">
-                      <img src={coiffureImage(coiffure)} alt={coiffure.nom} className="h-full w-full object-cover" />
-                      <button
-                        type="button"
-                        onClick={() => toggleFavorite(coiffure.id)}
-                        className="absolute right-3 top-3 grid h-10 w-10 place-items-center rounded-full bg-white/90 text-[#f31976] shadow-sm"
-                        aria-label="Ajouter aux favoris"
-                      >
-                        <Heart className={`h-5 w-5 ${favoriteIds.includes(coiffure.id) ? 'fill-[#f31976]' : ''}`} />
-                      </button>
-                    </div>
-                    <div className="p-4">
-                      <p className="line-clamp-1 text-sm font-black text-slate-950 sm:text-base">{coiffure.nom}</p>
-                      <p className="mt-1 text-xs font-bold text-slate-500">{coiffure.categorie?.nom ?? 'Coiffure'}</p>
-                      <p className="mt-3 text-xs font-semibold text-slate-500">A partir de</p>
-                      <div className="mt-1 flex items-end justify-between gap-2">
-                        <p className="text-sm font-black text-[#f31976]">{formatCurrency(coiffure.prix_min, devise)}</p>
-                        <p className="text-xs font-bold text-slate-500">{formatDuration(coiffure.duree_min_minutes)}</p>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => openDetails(coiffure)}
-                        className="mt-4 flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-950 px-3 py-3 text-sm font-black text-white transition group-hover:bg-[#f31976]"
-                      >
-                        Details
-                        <ChevronRight className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </article>
+                  <CoiffureCard
+                    key={coiffure.id}
+                    coiffure={coiffure}
+                    isFavorite={favoriteIds.includes(coiffure.id)}
+                    devise={devise}
+                    onToggleFavorite={toggleFavorite}
+                    onOpenDetails={openDetails}
+                  />
                 ))}
               </div>
             )}

--- a/frontend/src/features/client/client.helpers.ts
+++ b/frontend/src/features/client/client.helpers.ts
@@ -1,0 +1,132 @@
+import heroImage from '../../assets/hero.jpg'
+import type { ClientCoiffure, ClientPromotion, ClientSettings } from './client.types'
+
+// Helpers de formatage et calcul utilises a la fois par ClientHomePage et
+// les sous-composants extraits (CoiffureCard, etc.) - factorises ici pour
+// eviter la duplication et permettre le memo correct des composants enfants.
+
+export function formatCurrency(value: number | string, devise = 'FCFA') {
+  const amount = Number(value || 0)
+
+  return `${new Intl.NumberFormat('fr-FR').format(amount)} ${devise}`
+}
+
+export function formatDuration(minutes: number) {
+  if (minutes < 60) {
+    return `${minutes} min`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  const remaining = minutes % 60
+
+  return remaining > 0 ? `${hours}h ${remaining}min` : `${hours}h`
+}
+
+export function formatShortDate(value?: string | null) {
+  if (!value) {
+    return '-'
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+  }).format(date)
+}
+
+export function coiffureImage(coiffure: ClientCoiffure) {
+  return coiffure.image ?? coiffure.images[0]?.url ?? heroImage
+}
+
+export function promoText(promo: ClientPromotion) {
+  if (promo.type_reduction === 'pourcentage') {
+    return `-${Number(promo.valeur)}%`
+  }
+
+  return `-${formatCurrency(promo.valeur)}`
+}
+
+export function discountAmount(promo: ClientPromotion | null, total: number) {
+  if (!promo) {
+    return 0
+  }
+
+  if (promo.type_reduction === 'pourcentage') {
+    return Math.min(total, total * (Number(promo.valeur) / 100))
+  }
+
+  return Math.min(total, Number(promo.valeur))
+}
+
+export function depositAmount(total: number, settings?: ClientSettings) {
+  if (!settings) {
+    return 0
+  }
+
+  if (Number(settings.pourcentage_acompte) > 0) {
+    return total * (Number(settings.pourcentage_acompte) / 100)
+  }
+
+  return Math.min(Number(settings.montant_acompte_defaut || 0), total)
+}
+
+export const weekDays = [
+  'lundi',
+  'mardi',
+  'mercredi',
+  'jeudi',
+  'vendredi',
+  'samedi',
+  'dimanche',
+] as const
+
+export const weekDayLabels: Record<(typeof weekDays)[number], string> = {
+  lundi: 'Lundi',
+  mardi: 'Mardi',
+  mercredi: 'Mercredi',
+  jeudi: 'Jeudi',
+  vendredi: 'Vendredi',
+  samedi: 'Samedi',
+  dimanche: 'Dimanche',
+}
+
+export function dayKeyFromDate(dateString: string) {
+  const date = new Date(`${dateString}T00:00:00`)
+  const dayIndex = date.getDay()
+
+  return weekDays[(dayIndex + 6) % 7]
+}
+
+export function isClosedDate(dateString: string, settings?: ClientSettings) {
+  if (!settings?.jours_fermeture || settings.jours_fermeture.length === 0) {
+    return false
+  }
+
+  const key = dayKeyFromDate(dateString)
+
+  return settings.jours_fermeture.includes(key)
+}
+
+export function closedDaysLabel(days: string[]) {
+  if (!days || days.length === 0) {
+    return 'Ouvert toute la semaine'
+  }
+
+  return `Ferme: ${weekDays.filter((day) => days.includes(day)).map((day) => weekDayLabels[day]).join(', ')}`
+}
+
+export function toInputDate(date: Date) {
+  const normalized = new Date(date)
+  normalized.setMinutes(normalized.getMinutes() - normalized.getTimezoneOffset())
+
+  return normalized.toISOString().slice(0, 10)
+}
+
+export function todayInput() {
+  return toInputDate(new Date())
+}

--- a/frontend/src/features/client/components/CoiffureCard.tsx
+++ b/frontend/src/features/client/components/CoiffureCard.tsx
@@ -1,0 +1,67 @@
+import { memo } from 'react'
+import { ChevronRight, Heart } from 'lucide-react'
+import { coiffureImage, formatCurrency, formatDuration } from '../client.helpers'
+import type { ClientCoiffure } from '../client.types'
+
+type CoiffureCardProps = {
+  coiffure: ClientCoiffure
+  isFavorite: boolean
+  devise: string
+  onToggleFavorite: (id: number) => void
+  onOpenDetails: (coiffure: ClientCoiffure) => void
+}
+
+// Carte coiffure du catalogue. memo() est l optimisation cle (I11) :
+// avant, chaque frappe dans la barre de recherche OU dans le formulaire
+// de reservation provoquait un re-render des 8 cartes affichees, meme si
+// leur prop n avait pas change. Sur mobile en pic Tabaski, ca laguait
+// visiblement.
+//
+// Pour que memo bite reellement :
+// - le parent doit passer des callbacks stables (useCallback) ;
+// - isFavorite est passe en booleen pre-calcule (sinon passer le tableau
+//   favoriteIds entier casserait le memo a chaque modif d un favori) ;
+// - les autres props (coiffure, devise) sont stables tant que le catalogue
+//   et les settings ne changent pas.
+function CoiffureCardBase({
+  coiffure,
+  isFavorite,
+  devise,
+  onToggleFavorite,
+  onOpenDetails,
+}: CoiffureCardProps) {
+  return (
+    <article className="group overflow-hidden rounded-3xl border border-slate-100 bg-white shadow-sm">
+      <div className="relative aspect-[4/3] bg-rose-50">
+        <img src={coiffureImage(coiffure)} alt={coiffure.nom} className="h-full w-full object-cover" loading="lazy" />
+        <button
+          type="button"
+          onClick={() => onToggleFavorite(coiffure.id)}
+          className="absolute right-3 top-3 grid h-10 w-10 place-items-center rounded-full bg-white/90 text-[#f31976] shadow-sm"
+          aria-label="Ajouter aux favoris"
+        >
+          <Heart className={`h-5 w-5 ${isFavorite ? 'fill-[#f31976]' : ''}`} />
+        </button>
+      </div>
+      <div className="p-4">
+        <p className="line-clamp-1 text-sm font-black text-slate-950 sm:text-base">{coiffure.nom}</p>
+        <p className="mt-1 text-xs font-bold text-slate-500">{coiffure.categorie?.nom ?? 'Coiffure'}</p>
+        <p className="mt-3 text-xs font-semibold text-slate-500">A partir de</p>
+        <div className="mt-1 flex items-end justify-between gap-2">
+          <p className="text-sm font-black text-[#f31976]">{formatCurrency(coiffure.prix_min, devise)}</p>
+          <p className="text-xs font-bold text-slate-500">{formatDuration(coiffure.duree_min_minutes)}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onOpenDetails(coiffure)}
+          className="mt-4 flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-950 px-3 py-3 text-sm font-black text-white transition group-hover:bg-[#f31976]"
+        >
+          Details
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </article>
+  )
+}
+
+export const CoiffureCard = memo(CoiffureCardBase)

--- a/frontend/src/features/client/components/RatingStars.tsx
+++ b/frontend/src/features/client/components/RatingStars.tsx
@@ -1,0 +1,27 @@
+import { memo } from 'react'
+import { Star } from 'lucide-react'
+
+type RatingStarsProps = {
+  value: number
+  size?: 'xs' | 'sm'
+}
+
+// Etoiles d evaluation. memo() : le composant est utilise dans la liste des
+// avis du modal (potentiellement >10 occurrences) ; sans memo, chaque
+// frappe dans le formulaire reservation re-rendrait toutes les etoiles.
+function RatingStarsBase({ value, size = 'sm' }: RatingStarsProps) {
+  const iconSize = size === 'xs' ? 'h-3.5 w-3.5' : 'h-4 w-4'
+
+  return (
+    <span className="inline-flex items-center gap-0.5 text-[#f59e0b]">
+      {Array.from({ length: 5 }, (_, index) => (
+        <Star
+          key={index}
+          className={`${iconSize} ${index < Math.round(value) ? 'fill-[#f59e0b]' : 'fill-none text-slate-300'}`}
+        />
+      ))}
+    </span>
+  )
+}
+
+export const RatingStars = memo(RatingStarsBase)

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosError, type AxiosRequestConfig } from 'axios'
 
 // URL de l API. En dev, par defaut "/api" passe par le proxy Vite vers
 // le backend Laravel (cf vite.config.ts) -> tout est same-origin pour le
@@ -17,6 +17,10 @@ export const apiClient = axios.create({
   withCredentials: true,
   xsrfCookieName: 'XSRF-TOKEN',
   xsrfHeaderName: 'X-XSRF-TOKEN',
+  // Timeout de 15s : evite qu un appel reseau bloque indefiniment l UI
+  // (frequent en pic Tabaski avec backend sature). Au-dela, on entre dans
+  // le retry I12 qui peut redeclencher la requete.
+  timeout: 15000,
 })
 
 apiClient.interceptors.request.use((config) => {
@@ -28,3 +32,97 @@ apiClient.interceptors.request.use((config) => {
 
   return config
 })
+
+// ----------------------------------------------------------------------
+// Retry interceptor (I12)
+// ----------------------------------------------------------------------
+// Pendant le pic Tabaski, le backend peut renvoyer des 503 transitoires
+// (PHP-FPM saturating, base de donnees brieve indispo) ou la connexion peut
+// timeout. Sans retry, l utilisateur voit une erreur definitive alors qu un
+// simple re-essai 1-2s plus tard aurait reussi.
+//
+// Politique :
+// - Retry uniquement sur erreurs reseau / 5xx / 429 / timeouts.
+// - PAS sur 4xx (validation, auth, droits) : ce sont des erreurs business,
+//   re-essayer ne changera rien et masquerait des bugs.
+// - Backoff exponentiel + jitter : 0.5s + jitter, 1s + jitter, 2s + jitter
+//   pour eviter le "thundering herd" si tout le monde retry au meme moment.
+// - PAS sur les requetes NON-idempotentes par defaut (POST / PUT / PATCH /
+//   DELETE) sauf si la requete a explicitement opt-in via config.retry.
+//   Une POST de paiement re-jouee creerait un doublon.
+//
+// Pour opter-in cote appel : apiClient.get('/foo', { retry: { attempts: 5 } })
+// ----------------------------------------------------------------------
+
+type RetryConfig = {
+  attempts?: number
+  /** Liste des methodes idempotentes pour lesquelles le retry est applique. */
+  idempotentMethods?: readonly string[]
+}
+
+type RetriableConfig = AxiosRequestConfig & {
+  retry?: RetryConfig
+  /** Compteur interne incremente a chaque tentative. */
+  __retryCount?: number
+}
+
+const DEFAULT_RETRY: Required<RetryConfig> = {
+  attempts: 3,
+  idempotentMethods: ['get', 'head', 'options'],
+}
+
+const RETRIABLE_STATUSES = new Set([429, 500, 502, 503, 504])
+
+const RETRIABLE_NETWORK_CODES = new Set([
+  'ECONNABORTED', // axios timeout
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ENETUNREACH',
+])
+
+function shouldRetry(error: AxiosError, config: RetriableConfig): boolean {
+  const retry = { ...DEFAULT_RETRY, ...(config.retry ?? {}) }
+  const attempt = config.__retryCount ?? 0
+
+  if (attempt >= retry.attempts) {
+    return false
+  }
+
+  // Methode idempotente OU explicitement opt-in via config.retry ?
+  const method = (config.method ?? 'get').toLowerCase()
+  if (!retry.idempotentMethods.includes(method) && !config.retry) {
+    return false
+  }
+
+  // Erreur reseau (pas de reponse)
+  if (!error.response) {
+    return RETRIABLE_NETWORK_CODES.has(error.code ?? '')
+  }
+
+  return RETRIABLE_STATUSES.has(error.response.status)
+}
+
+/** Backoff exponentiel : 500ms, 1s, 2s + un jitter aleatoire de 0-300ms. */
+function backoffDelay(attempt: number): number {
+  const base = 500 * 2 ** attempt
+  const jitter = Math.floor(Math.random() * 300)
+  return base + jitter
+}
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const config = error.config as RetriableConfig | undefined
+
+    if (!config || !shouldRetry(error, config)) {
+      return Promise.reject(error)
+    }
+
+    config.__retryCount = (config.__retryCount ?? 0) + 1
+    const delay = backoffDelay(config.__retryCount - 1)
+
+    await new Promise((resolve) => setTimeout(resolve, delay))
+
+    return apiClient(config)
+  },
+)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,4 +25,52 @@ export default defineConfig({
       },
     },
   },
+
+  // ---------------------------------------------------------------------
+  // Build production (I10)
+  // ---------------------------------------------------------------------
+  build: {
+    // Pas de source maps en prod : evite de leak le code source frontend
+    // (logique de routing admin, structure des composants, etc.) sur le
+    // serveur public. Les source maps restent utiles en dev (defaut Vite).
+    sourcemap: false,
+
+    // Augmente le seuil d alerte de taille de chunk (defaut 500 kB).
+    // Avec le lazy loading des routes admin (I9), les chunks vendor sont
+    // les plus gros mais restent acceptables.
+    chunkSizeWarningLimit: 800,
+
+    rollupOptions: {
+      output: {
+        // Decoupage manuel des chunks vendor : isole React et React Router
+        // dans leur propre chunk pour qu ils soient caches par le navigateur
+        // entre les deploiements (l upgrade d une lib metier ne casse pas le
+        // cache de React, et inversement).
+        // Le reste de node_modules part dans un chunk "vendor" generique.
+        manualChunks: (id: string) => {
+          if (!id.includes('node_modules')) {
+            return undefined
+          }
+
+          if (id.includes('react-router')) {
+            return 'vendor-router'
+          }
+
+          if (id.includes('/react/') || id.includes('/react-dom/') || id.includes('/scheduler/')) {
+            return 'vendor-react'
+          }
+
+          if (id.includes('axios')) {
+            return 'vendor-axios'
+          }
+
+          if (id.includes('lucide-react')) {
+            return 'vendor-icons'
+          }
+
+          return 'vendor'
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Résumé
  Phase 3 (et finale) de l'audit pré-prod : optimisations performance frontend.
  Avec ce PR, l'audit côté code est terminé (12/14 IMPORTANTS, 8/9 BLOQUANTS,
  seul B1 Stripe reste manuel).

  ## Commits
  - I9 : lazy loading des 17 routes admin via React.lazy + Suspense.
    Bundle initial -83% (367 kB → 65 kB / 64 kB → 16 kB gzippé).
  - I10 : vite.config — manualChunks (vendor split React/Router/Axios/Icons),
    sourcemap=false anti-leak prod, chunkSizeWarningLimit ajusté.
  - I11 : refactor ClientHomePage (1522 → 1320 lignes). Extraction
    client.helpers.ts + components/RatingStars + components/CoiffureCard memo.
    useCallback sur toggleFavorite/openDetails pour stabiliser les refs et
    permettre au memo de fonctionner réellement.
  - I12 : interceptor axios retry exponentiel + jitter sur 5xx/timeout/réseau.
    Méthodes idempotentes seulement par défaut (anti-doublon paiement).
    Timeout 15s par défaut.

  ## Tests locaux
  - Build : OK (5 chunks vendor isolés, 0 fichier .map)
  - TypeScript : strict mode OK
  - UI : navigation admin = chunks lazy chargés à la demande

  ## À faire post-prod
  - I2 (Policies) : pour préparer multi-salon
  - I5 (garde rôle frontend) : juste documentaire
  - A1-A10 : améliorations post-launch
  - Modal de réservation : extraction reportée (state lourdement
    interconnecté, hors scope audit)