### PR TITLE
fix(phone): preflight check sur la migration pour eviter SQLSTATE 25P…

### DIFF
--- a/backend/database/migrations/2026_05_10_000001_normalize_existing_phones_to_e164.php
+++ b/backend/database/migrations/2026_05_10_000001_normalize_existing_phones_to_e164.php
@@ -2,7 +2,6 @@
 
 use App\Support\PhoneNumber;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -30,6 +29,15 @@ use Illuminate\Support\Facades\DB;
  */
 return new class extends Migration
 {
+    /**
+     * Opt-out de la transaction implicite Laravel : sur Postgres, la moindre
+     * exception SQL pendant la migration aborte la transaction entiere et
+     * toutes les requetes suivantes echouent en cascade (SQLSTATE 25P02).
+     * Cette migration n a aucune DDL et gere ses conflits via CSV, donc
+     * la transaction Laravel apporte plus de risque que de protection.
+     */
+    public $withinTransaction = false;
+
     public function up(): void
     {
         $timestamp = now()->format('Y-m-d_His');
@@ -87,18 +95,19 @@ return new class extends Migration
                         continue;
                     }
 
-                    try {
-                        DB::table('clients')->where('id', $c->id)->update(['telephone' => $normalized]);
-                        $stats['normalized']++;
-                    } catch (QueryException $e) {
-                        // On filtre uniquement les violations UNIQUE (toutes drivers : pgsql 23505,
-                        // sqlite "UNIQUE constraint", mysql "Duplicate entry"). Sinon on remonte.
-                        $msg = strtolower($e->getMessage());
-                        if (! str_contains($msg, 'unique') && ! str_contains($msg, 'duplicate')) {
-                            throw $e;
-                        }
+                    // Preflight check : on cherche d'abord si la valeur normalisee
+                    // existe deja sur une autre ligne, AVANT de tenter l'UPDATE.
+                    // Sinon, sur Postgres, l UPDATE qui viole la contrainte UNIQUE
+                    // aborte la transaction entiere -> toutes les queries suivantes
+                    // echouent en cascade avec SQLSTATE 25P02. Le try/catch PHP
+                    // attrape l exception mais Postgres reste dans un etat aborte.
+                    // Faire le check explicitement evite l exception completement.
+                    $other = DB::table('clients')
+                        ->where('telephone', $normalized)
+                        ->where('id', '!=', $c->id)
+                        ->first();
 
-                        $other = DB::table('clients')->where('telephone', $normalized)->first();
+                    if ($other !== null) {
                         fputcsv($handle, [
                             'unique_collision',
                             '',
@@ -115,7 +124,12 @@ return new class extends Migration
                             $this->lastActivity($c->id),
                         ]);
                         $stats['collisions']++;
+
+                        continue;
                     }
+
+                    DB::table('clients')->where('id', $c->id)->update(['telephone' => $normalized]);
+                    $stats['normalized']++;
                 }
             });
 


### PR DESCRIPTION
…02 Postgres

Sur Postgres, la moindre exception SQL pendant une transaction abort la transaction entiere et toutes les queries suivantes echouent en cascade (SQLSTATE 25P02 'current transaction is aborted'). Le try/catch PHP attrape bien l exception mais Postgres reste dans son etat aborte jusqu au ROLLBACK -> impossible de continuer la migration.

Deux changements :

1. Opt-out de la transaction implicite Laravel via la propriete $withinTransaction = false. La migration n a aucune DDL (juste des UPDATE et un CSV) donc on n a aucun besoin de transaction au niveau migration.

2. Remplacement du pattern try/catch sur QueryException UNIQUE par un preflight check : on cherche d abord si la valeur normalisee existe deja sur une autre ligne, et seulement apres on UPDATE. Plus aucune exception SQL declenchee -> Postgres reste healthy.

Teste sur la DB de dev : 3 conflits CSV generes correctement, migration boucle a son terme. Suite de tests (64 verts) toujours OK.

Note : la modif a ete decouverte et appliquee en local par l utilisateur lors du run de la migration sur des donnees reelles (3 conflits) - elle n etait pas dans la PR backend initiale (#48).