### PR TITLE
Feat/magic link whatsapp

### DIFF
--- a/backend/app/Http/Controllers/Api/Client/ClientSessionController.php
+++ b/backend/app/Http/Controllers/Api/Client/ClientSessionController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Api\Client;
+
+use App\Http\Controllers\Controller;
+use App\Services\ClientMagicLinkService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ClientSessionController extends Controller
+{
+    public function __construct(private readonly ClientMagicLinkService $magicLink) {}
+
+    /**
+     * POST /api/client/auth/magic-link
+     *
+     * Verifie le token magic link, cree une session 90j et pose le cookie.
+     * Token single-use : consomme immediatement a la verification.
+     */
+    public function verify(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'token' => ['required', 'string', 'size:64'],
+        ]);
+
+        $client = $this->magicLink->verifyMagicLink($data['token']);
+
+        if (! $client) {
+            return response()->json([
+                'message' => 'Lien invalide ou expiré.',
+            ], 422);
+        }
+
+        $sessionToken = $this->magicLink->createSession($client);
+
+        return response()->json([
+            'message' => 'Connexion reussie.',
+            'data' => [
+                'nom' => $client->nom,
+                'prenom' => $client->prenom,
+                'telephone' => $client->telephone,
+            ],
+        ])->cookie(
+            'bt_client_session',
+            $sessionToken,
+            60 * 24 * 90, // 90 jours en minutes
+            '/',
+            null,
+            app()->isProduction(), // Secure uniquement en prod (HTTPS)
+            true,  // httpOnly
+            false, // raw
+            'lax', // sameSite
+        );
+    }
+
+    /**
+     * GET /api/client/session
+     *
+     * Retourne les infos du client connecte (cookie valide requis).
+     * Utilise par le frontend au montage pour le prefill automatique.
+     */
+    public function session(Request $request): JsonResponse
+    {
+        /** @var \App\Models\Client $client */
+        $client = $request->get('clientSession');
+
+        return response()->json([
+            'data' => [
+                'nom' => $client->nom,
+                'prenom' => $client->prenom,
+                'telephone' => $client->telephone,
+            ],
+        ]);
+    }
+
+    /**
+     * DELETE /api/client/session
+     *
+     * Deconnecte le client : revoque le session token en DB et efface le cookie.
+     */
+    public function logout(Request $request): JsonResponse
+    {
+        /** @var \App\Models\Client $client */
+        $client = $request->get('clientSession');
+        $this->magicLink->revokeSession($client);
+
+        return response()->json(['message' => 'Deconnecte.'])
+            ->withoutCookie('bt_client_session');
+    }
+}

--- a/backend/app/Http/Controllers/Api/Client/PaymentController.php
+++ b/backend/app/Http/Controllers/Api/Client/PaymentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Client;
 
 use App\Http\Controllers\Controller;
+use App\Jobs\SendMagicLinkNotification;
 use App\Jobs\SendPaymentReceiptNotifications;
 use App\Models\Paiement;
 use App\Models\Reservation;
@@ -310,6 +311,10 @@ class PaymentController extends Controller
         // Twilio/WhatsApp/Mail synchrones). Un worker queue:work consomme
         // la queue Redis et envoie le recu en arriere-plan.
         SendPaymentReceiptNotifications::dispatch($payment->id);
+        // Magic link (Phase 5 etape 2) : lien de session 90j envoye par WhatsApp
+        // apres chaque paiement confirme. Si WhatsApp n est pas configure, le
+        // job log un warning et sort proprement (pas d exception).
+        SendMagicLinkNotification::dispatch($payment->id);
     }
 
     private function markPaymentAsCanceled(Paiement $payment, string $reference): void

--- a/backend/app/Http/Middleware/AuthenticateClientSession.php
+++ b/backend/app/Http/Middleware/AuthenticateClientSession.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\ClientMagicLinkService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifie le cookie de session client `bt_client_session`.
+ *
+ * Si valide, injecte `$request->clientSession` (instance Client).
+ * Si invalide ou absent, retourne 401 (les routes protegees en ont besoin).
+ */
+class AuthenticateClientSession
+{
+    public function __construct(private readonly ClientMagicLinkService $magicLink) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $raw = $request->cookie('bt_client_session');
+
+        if (! $raw || ! is_string($raw)) {
+            return response()->json(['message' => 'Session expirée. Reconnectez-vous via votre lien WhatsApp.'], 401);
+        }
+
+        $client = $this->magicLink->clientFromSession($raw);
+
+        if (! $client) {
+            return response()->json(['message' => 'Session expirée. Reconnectez-vous via votre lien WhatsApp.'], 401)
+                ->withoutCookie('bt_client_session');
+        }
+
+        $request->merge(['clientSession' => $client]);
+
+        return $next($request);
+    }
+}

--- a/backend/app/Jobs/SendMagicLinkNotification.php
+++ b/backend/app/Jobs/SendMagicLinkNotification.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Paiement;
+use App\Services\ClientMagicLinkService;
+use App\Services\WhatsappService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Envoie le magic link WhatsApp au client apres validation du paiement.
+ *
+ * Dispatche de facon asynchrone (meme pattern que SendPaymentReceiptNotifications)
+ * pour ne pas bloquer la reponse webhook. Le client recoit le lien dans les
+ * secondes qui suivent la confirmation de paiement.
+ *
+ * Si WhatsApp n est pas configure (dev, test), le job log un warning et sort
+ * proprement sans faire planter la queue.
+ */
+class SendMagicLinkNotification implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function backoff(): array
+    {
+        return [10, 30, 60];
+    }
+
+    public function __construct(public readonly int $paiementId) {}
+
+    public function handle(ClientMagicLinkService $magicLink, WhatsappService $whatsapp): void
+    {
+        $paiement = Paiement::query()->with(['client', 'reservation.client'])->find($this->paiementId);
+
+        if (! $paiement) {
+            Log::warning('SendMagicLinkNotification : paiement introuvable', ['paiement_id' => $this->paiementId]);
+
+            return;
+        }
+
+        $client = $paiement->client ?? $paiement->reservation?->client;
+
+        if (! $client || ! $client->telephone) {
+            return;
+        }
+
+        $rawToken = $magicLink->generateMagicLink($client);
+        $url = $magicLink->buildUrl($rawToken);
+
+        $message = implode("\n", [
+            "Bonjour {$client->prenom},",
+            'Votre reservation chez Bichette Thomas est confirmee.',
+            '',
+            'Retrouvez et gerez vos reservations en 1 clic :',
+            $url,
+            '',
+            'Ce lien est valable 24h.',
+        ]);
+
+        $sent = $whatsapp->send($client->telephone, $message, 'magic-link-' . $client->id);
+
+        if (! $sent) {
+            Log::info('SendMagicLinkNotification : WhatsApp non configure ou inaccessible', [
+                'client_id' => $client->id,
+            ]);
+        }
+    }
+}

--- a/backend/app/Services/ClientMagicLinkService.php
+++ b/backend/app/Services/ClientMagicLinkService.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Client;
+use Illuminate\Support\Str;
+
+/**
+ * Gestion des magic links et sessions clients (Phase 5 etape 2).
+ *
+ * Principe : on stocke uniquement le hash SHA-256 du token en base.
+ * Le token brut ne vit que dans le lien WhatsApp (magic link) ou dans
+ * le cookie httpOnly (session). Si la DB est compromise, les tokens
+ * bruts restent inconnus de l attaquant.
+ */
+class ClientMagicLinkService
+{
+    private const MAGIC_LINK_TTL_HOURS = 24;
+
+    private const SESSION_TTL_DAYS = 90;
+
+    // -----------------------------------------------------------------
+    // Magic link (single-use, TTL 24h)
+    // -----------------------------------------------------------------
+
+    /**
+     * Genere un magic link token pour le client.
+     * Retourne le token brut a inclure dans l URL WhatsApp.
+     * Ecrase le precedent token non-utilise (un seul lien valide a la fois).
+     */
+    public function generateMagicLink(Client $client): string
+    {
+        $raw = Str::random(64);
+
+        $client->forceFill([
+            'magic_link_token' => hash('sha256', $raw),
+            'magic_link_expires_at' => now()->addHours(self::MAGIC_LINK_TTL_HOURS),
+        ])->save();
+
+        return $raw;
+    }
+
+    /**
+     * Verifie un token magic link.
+     * Retourne le client et consomme le token (single-use).
+     * Retourne null si invalide ou expire.
+     */
+    public function verifyMagicLink(string $rawToken): ?Client
+    {
+        $hash = hash('sha256', $rawToken);
+
+        $client = Client::query()
+            ->where('magic_link_token', $hash)
+            ->where('magic_link_expires_at', '>', now())
+            ->first();
+
+        if (! $client) {
+            return null;
+        }
+
+        // Consommation : on efface le token pour qu il ne puisse pas etre rejoue.
+        $client->forceFill([
+            'magic_link_token' => null,
+            'magic_link_expires_at' => null,
+        ])->save();
+
+        return $client;
+    }
+
+    // -----------------------------------------------------------------
+    // Session persistante (cookie 90 jours)
+    // -----------------------------------------------------------------
+
+    /**
+     * Cree une session persistante pour le client.
+     * Retourne le token brut a poser dans le cookie httpOnly.
+     */
+    public function createSession(Client $client): string
+    {
+        $raw = Str::random(64);
+
+        $client->forceFill([
+            'session_token' => hash('sha256', $raw),
+            'session_expires_at' => now()->addDays(self::SESSION_TTL_DAYS),
+        ])->save();
+
+        return $raw;
+    }
+
+    /**
+     * Retrouve le client depuis un token de session brut (issu du cookie).
+     * Retourne null si invalide, expire, ou client blackliste.
+     */
+    public function clientFromSession(string $rawToken): ?Client
+    {
+        $hash = hash('sha256', $rawToken);
+
+        return Client::query()
+            ->where('session_token', $hash)
+            ->where('session_expires_at', '>', now())
+            ->where('est_blackliste', false)
+            ->first();
+    }
+
+    /**
+     * Revoque la session du client (deconnexion).
+     */
+    public function revokeSession(Client $client): void
+    {
+        $client->forceFill([
+            'session_token' => null,
+            'session_expires_at' => null,
+        ])->save();
+    }
+
+    // -----------------------------------------------------------------
+    // URL
+    // -----------------------------------------------------------------
+
+    /**
+     * Construit l URL du magic link a inclure dans le message WhatsApp.
+     */
+    public function buildUrl(string $rawToken): string
+    {
+        $base = rtrim((string) config('app.frontend_url', config('app.url')), '/');
+
+        return $base . '/client?magic_token=' . $rawToken;
+    }
+}

--- a/backend/app/Services/PaymentReceiptNotificationService.php
+++ b/backend/app/Services/PaymentReceiptNotificationService.php
@@ -5,12 +5,13 @@ namespace App\Services;
 use App\Mail\ReservationConfirmationMail;
 use App\Models\Paiement;
 use App\Support\SystemSettings;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
 class PaymentReceiptNotificationService
 {
+    public function __construct(private readonly WhatsappService $whatsapp) {}
+
     public function send(Paiement $paiement): array
     {
         $paiement->loadMissing(['client', 'reservation.client', 'reservation.details']);
@@ -108,143 +109,35 @@ class PaymentReceiptNotificationService
      */
     private function sendWhatsapp(array $receipt, string $message): bool
     {
-        $to = $this->whatsappPhone($receipt['telephone'] ?? null);
+        $to = $receipt['telephone'] ?? null;
 
         if (! $to) {
             return false;
         }
 
-        if ($this->sendWhatsappViaTwilio($to, $message, $receipt)) {
-            return true;
-        }
-
-        return $this->sendWhatsappViaCloudApi($to, $message, $receipt);
-    }
-
-    /**
-     * @param array<string, mixed> $receipt
-     */
-    private function sendWhatsappViaTwilio(string $to, string $message, array $receipt): bool
-    {
-        $accountSid = config('services.twilio.account_sid');
-        $authToken = config('services.twilio.auth_token');
-        $from = $this->twilioWhatsappAddress(config('services.twilio.whatsapp_from'));
-        $toAddress = $this->twilioWhatsappAddress($to);
-
-        if (! $accountSid || ! $authToken || ! $from || ! $toAddress) {
-            return false;
-        }
-
-        try {
-            $response = Http::withBasicAuth($accountSid, $authToken)
-                ->post("https://api.twilio.com/2010-04-01/Accounts/{$accountSid}/Messages", [
-                    'From' => $from,
-                    'To' => $toAddress,
-                    'Body' => $message,
-                ]);
-
-            if ($response->failed()) {
-                Log::warning('Twilio WhatsApp receipt message failed', [
-                    'paiement' => $receipt['numero_recu'],
-                    'status' => $response->status(),
-                    'body' => $response->json(),
-                ]);
-
-                return false;
-            }
-
-            return true;
-        } catch (\Throwable $exception) {
-            Log::warning('Twilio WhatsApp receipt message exception', [
-                'paiement' => $receipt['numero_recu'],
-                'message' => $exception->getMessage(),
-            ]);
-
-            return false;
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $receipt
-     */
-    private function sendWhatsappViaCloudApi(string $to, string $message, array $receipt): bool
-    {
-        $token = config('services.whatsapp.access_token');
-        $phoneNumberId = config('services.whatsapp.phone_number_id');
-
-        if (! $token || ! $phoneNumberId) {
-            return false;
-        }
-
-        try {
-            $response = Http::withToken((string) $token)
-                ->acceptJson()
-                ->post(rtrim((string) config('services.whatsapp.base_url'), '/') . "/{$phoneNumberId}/messages", $this->whatsappPayload($to, $receipt, $message));
-
-            if ($response->failed()) {
-                Log::warning('WhatsApp Cloud receipt message failed', [
-                    'paiement' => $receipt['numero_recu'],
-                    'status' => $response->status(),
-                    'body' => $response->json(),
-                ]);
-
-                return false;
-            }
-
-            return true;
-        } catch (\Throwable $exception) {
-            Log::warning('WhatsApp Cloud receipt message exception', [
-                'paiement' => $receipt['numero_recu'],
-                'message' => $exception->getMessage(),
-            ]);
-
-            return false;
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $receipt
-     *
-     * @return array<string, mixed>
-     */
-    private function whatsappPayload(string $to, array $receipt, string $message): array
-    {
         $template = config('services.whatsapp.receipt_template_name');
+        $context = 'recu-' . $receipt['numero_recu'];
 
         if ($template) {
-            return [
-                'messaging_product' => 'whatsapp',
-                'recipient_type' => 'individual',
-                'to' => $to,
-                'type' => 'template',
-                'template' => [
-                    'name' => $template,
-                    'language' => ['code' => config('services.whatsapp.receipt_template_language', 'fr')],
-                    'components' => [[
-                        'type' => 'body',
-                        'parameters' => [
-                            ['type' => 'text', 'text' => (string) $receipt['client_nom']],
-                            ['type' => 'text', 'text' => (string) $receipt['numero_recu']],
-                            ['type' => 'text', 'text' => (string) ($receipt['services'][0] ?? 'Reservation')],
-                            ['type' => 'text', 'text' => trim(($receipt['date_reservation'] ?? '') . ' ' . ($receipt['heure_debut'] ?? ''))],
-                            ['type' => 'text', 'text' => $this->money($receipt['montant_paye'], $receipt['devise'])],
-                            ['type' => 'text', 'text' => $this->money($receipt['reste_a_payer'], $receipt['devise'])],
-                        ],
-                    ]],
-                ],
-            ];
+            return $this->whatsapp->sendTemplate(
+                $to,
+                $template,
+                [[
+                    'type' => 'body',
+                    'parameters' => [
+                        ['type' => 'text', 'text' => (string) $receipt['client_nom']],
+                        ['type' => 'text', 'text' => (string) $receipt['numero_recu']],
+                        ['type' => 'text', 'text' => (string) ($receipt['services'][0] ?? 'Reservation')],
+                        ['type' => 'text', 'text' => trim(($receipt['date_reservation'] ?? '') . ' ' . ($receipt['heure_debut'] ?? ''))],
+                        ['type' => 'text', 'text' => $this->money($receipt['montant_paye'], $receipt['devise'])],
+                        ['type' => 'text', 'text' => $this->money($receipt['reste_a_payer'], $receipt['devise'])],
+                    ],
+                ]],
+                $context,
+            );
         }
 
-        return [
-            'messaging_product' => 'whatsapp',
-            'recipient_type' => 'individual',
-            'to' => $to,
-            'type' => 'text',
-            'text' => [
-                'preview_url' => false,
-                'body' => $message,
-            ],
-        ];
+        return $this->whatsapp->send($to, $message, $context);
     }
 
     /**
@@ -280,46 +173,6 @@ class PaymentReceiptNotificationService
 
             return false;
         }
-    }
-
-    private function whatsappPhone(?string $phone): ?string
-    {
-        $digits = preg_replace('/\D+/', '', (string) $phone) ?? '';
-
-        if ($digits === '') {
-            return null;
-        }
-
-        if (str_starts_with($digits, '00')) {
-            $digits = substr($digits, 2);
-        }
-
-        if (str_starts_with($digits, '221')) {
-            return $digits;
-        }
-
-        if (strlen($digits) === 9) {
-            return '221' . $digits;
-        }
-
-        return $digits;
-    }
-
-    private function twilioWhatsappAddress(mixed $phone): ?string
-    {
-        $raw = trim((string) $phone);
-
-        if ($raw === '') {
-            return null;
-        }
-
-        if (str_starts_with($raw, 'whatsapp:')) {
-            return $raw;
-        }
-
-        $normalized = $this->whatsappPhone($raw);
-
-        return $normalized ? 'whatsapp:+' . $normalized : null;
     }
 
     private function reservationPaidAmount(int $reservationId): float

--- a/backend/app/Services/WhatsappService.php
+++ b/backend/app/Services/WhatsappService.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Envoi de messages WhatsApp via Twilio (prioritaire) ou Meta Cloud API (fallback).
+ *
+ * Utilise par PaymentReceiptNotificationService (recu de paiement) et
+ * SendMagicLinkNotification (lien de connexion). Centralise ici pour eviter
+ * la duplication et permettre d ajouter un troisieme provider sans toucher
+ * aux consommateurs.
+ */
+class WhatsappService
+{
+    /**
+     * Envoie un message texte libre. Retourne true si au moins un provider a reussi.
+     */
+    public function send(string $to, string $message, string $context = 'whatsapp'): bool
+    {
+        $normalized = $this->normalizePhone($to);
+
+        if (! $normalized) {
+            return false;
+        }
+
+        if ($this->sendViaTwilio($normalized, $message, $context)) {
+            return true;
+        }
+
+        return $this->sendViaCloudApi($normalized, $message, $context);
+    }
+
+    /**
+     * Envoie via un template WhatsApp Cloud API (pour les messages structures).
+     * Retourne false et tombe en fallback texte si le template n est pas configure.
+     *
+     * @param array<string, mixed> $templateComponents
+     */
+    public function sendTemplate(string $to, string $templateName, array $templateComponents, string $context = 'whatsapp'): bool
+    {
+        $normalized = $this->normalizePhone($to);
+
+        if (! $normalized) {
+            return false;
+        }
+
+        $token = config('services.whatsapp.access_token');
+        $phoneNumberId = config('services.whatsapp.phone_number_id');
+
+        if (! $token || ! $phoneNumberId) {
+            return false;
+        }
+
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'recipient_type' => 'individual',
+            'to' => $normalized,
+            'type' => 'template',
+            'template' => [
+                'name' => $templateName,
+                'language' => ['code' => config('services.whatsapp.template_language', 'fr')],
+                'components' => $templateComponents,
+            ],
+        ];
+
+        try {
+            $response = Http::withToken((string) $token)
+                ->acceptJson()
+                ->post(rtrim((string) config('services.whatsapp.base_url'), '/') . "/{$phoneNumberId}/messages", $payload);
+
+            if ($response->failed()) {
+                Log::warning("WhatsApp Cloud template failed [{$context}]", [
+                    'status' => $response->status(),
+                    'body' => $response->json(),
+                ]);
+
+                return false;
+            }
+
+            return true;
+        } catch (ConnectionException|\Throwable $e) {
+            Log::warning("WhatsApp Cloud template exception [{$context}]", ['message' => $e->getMessage()]);
+
+            return false;
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Providers
+    // -----------------------------------------------------------------
+
+    private function sendViaTwilio(string $to, string $message, string $context): bool
+    {
+        $accountSid = config('services.twilio.account_sid');
+        $authToken = config('services.twilio.auth_token');
+        $from = $this->twilioAddress(config('services.twilio.whatsapp_from'));
+        $toAddress = $this->twilioAddress($to);
+
+        if (! $accountSid || ! $authToken || ! $from || ! $toAddress) {
+            return false;
+        }
+
+        try {
+            $response = Http::withBasicAuth($accountSid, $authToken)
+                ->post("https://api.twilio.com/2010-04-01/Accounts/{$accountSid}/Messages", [
+                    'From' => $from,
+                    'To' => $toAddress,
+                    'Body' => $message,
+                ]);
+
+            if ($response->failed()) {
+                Log::warning("Twilio WhatsApp failed [{$context}]", [
+                    'status' => $response->status(),
+                    'body' => $response->json(),
+                ]);
+
+                return false;
+            }
+
+            return true;
+        } catch (ConnectionException|\Throwable $e) {
+            Log::warning("Twilio WhatsApp exception [{$context}]", ['message' => $e->getMessage()]);
+
+            return false;
+        }
+    }
+
+    private function sendViaCloudApi(string $to, string $message, string $context): bool
+    {
+        $token = config('services.whatsapp.access_token');
+        $phoneNumberId = config('services.whatsapp.phone_number_id');
+
+        if (! $token || ! $phoneNumberId) {
+            return false;
+        }
+
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'recipient_type' => 'individual',
+            'to' => $to,
+            'type' => 'text',
+            'text' => ['preview_url' => true, 'body' => $message],
+        ];
+
+        try {
+            $response = Http::withToken((string) $token)
+                ->acceptJson()
+                ->post(rtrim((string) config('services.whatsapp.base_url'), '/') . "/{$phoneNumberId}/messages", $payload);
+
+            if ($response->failed()) {
+                Log::warning("WhatsApp Cloud API failed [{$context}]", [
+                    'status' => $response->status(),
+                    'body' => $response->json(),
+                ]);
+
+                return false;
+            }
+
+            return true;
+        } catch (ConnectionException|\Throwable $e) {
+            Log::warning("WhatsApp Cloud API exception [{$context}]", ['message' => $e->getMessage()]);
+
+            return false;
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    public function normalizePhone(?string $phone): ?string
+    {
+        $digits = preg_replace('/\D+/', '', (string) $phone) ?? '';
+
+        if ($digits === '') {
+            return null;
+        }
+
+        if (str_starts_with($digits, '00')) {
+            $digits = substr($digits, 2);
+        }
+
+        // Retourne sans le '+' : format attendu par Twilio et Cloud API.
+        if (str_starts_with($digits, '221')) {
+            return $digits;
+        }
+
+        if (strlen($digits) === 9) {
+            return '221' . $digits;
+        }
+
+        return $digits;
+    }
+
+    private function twilioAddress(mixed $phone): ?string
+    {
+        $raw = trim((string) $phone);
+
+        if ($raw === '') {
+            return null;
+        }
+
+        if (str_starts_with($raw, 'whatsapp:')) {
+            return $raw;
+        }
+
+        $normalized = $this->normalizePhone($raw);
+
+        return $normalized ? 'whatsapp:+' . $normalized : null;
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -16,9 +16,11 @@ return Application::configure(basePath: dirname(__DIR__))
         // Alias des middlewares custom utilises dans routes/api.php.
         $middleware->alias([
             'auth.token' => App\Http\Middleware\AuthenticateApiToken::class,
+            'auth.client.session' => App\Http\Middleware\AuthenticateClientSession::class,
             'log.admin' => App\Http\Middleware\LogAdminAction::class,
             'role' => App\Http\Middleware\EnsureUserHasRole::class,
         ]);
+
 
         // TrustProxies (B6) : le nginx interne tourne en HTTP derriere un
         // reverse-proxy TLS (Cloudflare, Caddy, AWS ELB...). Sans cette

--- a/backend/database/migrations/2026_05_12_000001_add_magic_link_and_session_to_clients_table.php
+++ b/backend/database/migrations/2026_05_12_000001_add_magic_link_and_session_to_clients_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clients', function (Blueprint $table): void {
+            // Magic link : token single-use (24h) envoye par WhatsApp apres paiement.
+            // On stocke le hash SHA-256 du token brut (le brut ne vit que dans le lien).
+            $table->string('magic_link_token', 128)->nullable()->unique()->after('notes');
+            $table->timestamp('magic_link_expires_at')->nullable()->after('magic_link_token');
+
+            // Session persistante (90 jours) posee apres verification du magic link.
+            // Meme principe : hash en base, token brut uniquement dans le cookie httpOnly.
+            $table->string('session_token', 128)->nullable()->unique()->after('magic_link_expires_at');
+            $table->timestamp('session_expires_at')->nullable()->after('session_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clients', function (Blueprint $table): void {
+            $table->dropColumn(['magic_link_token', 'magic_link_expires_at', 'session_token', 'session_expires_at']);
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\Api\Admin\VarianteCoiffureController;
 use App\Http\Controllers\Api\AnalyticsController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\Client\CatalogueController as ClientCatalogueController;
+use App\Http\Controllers\Api\Client\ClientSessionController;
 use App\Http\Controllers\Api\Client\PaymentController as ClientPaymentController;
 use App\Http\Controllers\Api\Client\ReservationAvailabilityController as ClientReservationAvailabilityController;
 use App\Http\Controllers\Api\Client\ReservationController as ClientReservationController;
@@ -45,10 +46,14 @@ Route::prefix('client')->name('client.')->group(function (): void {
     Route::get('/catalogue', [ClientCatalogueController::class, 'index'])->name('catalogue.index');
     Route::get('/catalogue/{coiffure}', [ClientCatalogueController::class, 'show'])->name('catalogue.show');
     Route::post('/catalogue/{coiffure}/avis', [ClientCatalogueController::class, 'storeAvis'])->middleware('throttle:10,1')->name('catalogue.avis.store');
-    // Lookup tel international (Phase 5 etape 1) : prefill auto nom/prenom au
-    // checkout. Throttle serre (5/min/IP) anti-annuaire-inverse + privacy-safe
-    // (jamais d email, jamais d id, jamais d historique).
+    // Lookup tel international (Phase 5 etape 1).
     Route::get('/lookup', [ClientCatalogueController::class, 'lookup'])->middleware('throttle:5,1')->name('lookup');
+    // Magic link + session client (Phase 5 etape 2).
+    Route::post('/auth/magic-link', [ClientSessionController::class, 'verify'])->middleware('throttle:10,1')->name('auth.magic-link');
+    Route::middleware('auth.client.session')->group(function (): void {
+        Route::get('/session', [ClientSessionController::class, 'session'])->name('session');
+        Route::delete('/session', [ClientSessionController::class, 'logout'])->name('session.logout');
+    });
     Route::get('/reservations/disponibilites', ClientReservationAvailabilityController::class)->name('reservations.availability');
     Route::post('/reservations', [ClientReservationController::class, 'store'])->middleware('throttle:10,1')->name('reservations.store');
     Route::post('/paiements/stripe/confirmer', [ClientPaymentController::class, 'confirmStripeCheckout'])->middleware('throttle:20,1')->name('payments.stripe.confirm');

--- a/backend/tests/Feature/Client/MagicLinkTest.php
+++ b/backend/tests/Feature/Client/MagicLinkTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Tests\Feature\Client;
+
+use App\Jobs\SendMagicLinkNotification;
+use App\Models\Client;
+use App\Models\Paiement;
+use App\Models\Reservation;
+use App\Services\ClientMagicLinkService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+/**
+ * Tests d integration Phase 5 etape 2 : magic link + session client.
+ *
+ * Couvre :
+ * - Token valide -> session posee, cookie present, donnees client retournees
+ * - Token expire -> 422
+ * - Token deja utilise (single-use) -> 422
+ * - Token inconnu -> 422
+ * - GET /session avec cookie valide -> donnees client
+ * - GET /session sans cookie -> 401
+ * - DELETE /session -> cookie efface, token revoque en DB
+ * - Client blackliste -> session rejetee
+ * - Paiement confirme -> job SendMagicLinkNotification dispatche
+ */
+class MagicLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -----------------------------------------------------------------
+    // POST /api/client/auth/magic-link (verification du token)
+    // -----------------------------------------------------------------
+
+    public function test_token_valide_pose_un_cookie_et_retourne_les_donnees_client(): void
+    {
+        $client = $this->createClient();
+        $service = app(ClientMagicLinkService::class);
+        $rawToken = $service->generateMagicLink($client);
+
+        $response = $this->postJson('/api/client/auth/magic-link', ['token' => $rawToken]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.nom', $client->nom);
+        $response->assertJsonPath('data.prenom', $client->prenom);
+        $response->assertJsonPath('data.telephone', $client->telephone);
+        $response->assertCookie('bt_client_session');
+
+        // Token consomme en DB (single-use).
+        $this->assertNull($client->fresh()->magic_link_token);
+    }
+
+    public function test_token_expire_retourne_422(): void
+    {
+        $client = $this->createClient();
+        $service = app(ClientMagicLinkService::class);
+        $rawToken = $service->generateMagicLink($client);
+
+        // Expire manuellement le token.
+        $client->forceFill(['magic_link_expires_at' => now()->subMinute()])->save();
+
+        $response = $this->postJson('/api/client/auth/magic-link', ['token' => $rawToken]);
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('message', 'Lien invalide ou expiré.');
+        $response->assertCookieMissing('bt_client_session');
+    }
+
+    public function test_token_deja_utilise_retourne_422(): void
+    {
+        $client = $this->createClient();
+        $service = app(ClientMagicLinkService::class);
+        $rawToken = $service->generateMagicLink($client);
+
+        // Premier appel consomme le token.
+        $this->postJson('/api/client/auth/magic-link', ['token' => $rawToken])->assertOk();
+
+        // Deuxieme appel sur le meme token.
+        $response = $this->postJson('/api/client/auth/magic-link', ['token' => $rawToken]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_token_inconnu_retourne_422(): void
+    {
+        $response = $this->postJson('/api/client/auth/magic-link', [
+            'token' => str_repeat('a', 64),
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_token_trop_court_echoue_la_validation(): void
+    {
+        $response = $this->postJson('/api/client/auth/magic-link', ['token' => 'court']);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['token']);
+    }
+
+    // -----------------------------------------------------------------
+    // GET /api/client/session
+    // -----------------------------------------------------------------
+
+    public function test_session_avec_cookie_valide_retourne_les_donnees_client(): void
+    {
+        $client = $this->createClient();
+        $cookies = $this->loginClient($client);
+
+        $response = $this->withCredentials()->withUnencryptedCookies($cookies)
+            ->getJson('/api/client/session');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.nom', $client->nom);
+        $response->assertJsonPath('data.prenom', $client->prenom);
+        $response->assertJsonPath('data.telephone', $client->telephone);
+    }
+
+    public function test_session_sans_cookie_retourne_401(): void
+    {
+        $response = $this->getJson('/api/client/session');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_session_avec_cookie_expire_retourne_401(): void
+    {
+        $client = $this->createClient();
+        $cookies = $this->loginClient($client);
+
+        // Expire la session en DB apres l'avoir creee via verify.
+        $client->forceFill(['session_expires_at' => now()->subMinute()])->save();
+
+        $response = $this->withCredentials()->withUnencryptedCookies($cookies)
+            ->getJson('/api/client/session');
+
+        $response->assertStatus(401);
+    }
+
+    // -----------------------------------------------------------------
+    // DELETE /api/client/session
+    // -----------------------------------------------------------------
+
+    public function test_logout_revoque_le_token_et_efface_le_cookie(): void
+    {
+        $client = $this->createClient();
+        $cookies = $this->loginClient($client);
+
+        $response = $this->withCredentials()->withUnencryptedCookies($cookies)
+            ->deleteJson('/api/client/session');
+
+        $response->assertOk();
+
+        // Token revoque en DB.
+        $this->assertNull($client->fresh()->session_token);
+
+        // La session suivante doit etre rejetee (meme cookie chiffre, token efface en DB).
+        $this->withCredentials()->withUnencryptedCookies($cookies)
+            ->getJson('/api/client/session')
+            ->assertStatus(401);
+    }
+
+    // -----------------------------------------------------------------
+    // Client blackliste
+    // -----------------------------------------------------------------
+
+    public function test_client_blackliste_ne_peut_pas_utiliser_sa_session(): void
+    {
+        $client = $this->createClient();
+        $cookies = $this->loginClient($client);
+
+        $client->forceFill(['est_blackliste' => true])->save();
+
+        $response = $this->withCredentials()->withUnencryptedCookies($cookies)
+            ->getJson('/api/client/session');
+
+        $response->assertStatus(401);
+    }
+
+    // -----------------------------------------------------------------
+    // Dispatch du job apres paiement confirme
+    // -----------------------------------------------------------------
+
+    public function test_paiement_valide_dispatche_le_job_magic_link(): void
+    {
+        Bus::fake();
+        config([
+            'services.paytech.api_key' => 'fake-key',
+            'services.paytech.api_secret' => 'fake-secret',
+        ]);
+
+        $payment = $this->createPendingPayment();
+
+        $hmac = hash_hmac('sha256', "5000|BT-PAY-1-ML|fake-key", 'fake-secret');
+        $this->postJson('/api/client/paiements/paytech/ipn', [
+            'type_event' => 'sale_complete',
+            'item_price' => 5000,
+            'final_item_price' => 5000,
+            'ref_command' => 'BT-PAY-1-ML',
+            'token' => 'tok-ml',
+            'custom_field' => json_encode(['paiement_id' => $payment->id]),
+            'hmac_compute' => $hmac,
+        ])->assertOk();
+
+        Bus::assertDispatched(SendMagicLinkNotification::class, fn ($job) => $job->paiementId === $payment->id);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    /**
+     * Cree une session client valide via l'endpoint verify et retourne
+     * le cookie chiffre pret a etre passe avec withUnencryptedCookies().
+     *
+     * Meme patron que TestCase::authenticatedAs() pour les admins :
+     * on passe par le vrai endpoint pour que Laravel chiffre le cookie
+     * lui-meme, puis on rejoue ce cookie chiffre dans les requetes suivantes.
+     *
+     * @return array<string, string>
+     */
+    private function loginClient(Client $client): array
+    {
+        $service = app(ClientMagicLinkService::class);
+        $rawToken = $service->generateMagicLink($client);
+
+        $verifyResponse = $this->postJson('/api/client/auth/magic-link', ['token' => $rawToken]);
+        $verifyResponse->assertOk();
+
+        $cookies = [];
+        foreach ($verifyResponse->headers->getCookies() as $cookie) {
+            if ($cookie->getName() === 'bt_client_session') {
+                $cookies[$cookie->getName()] = $cookie->getValue();
+            }
+        }
+
+        return $cookies;
+    }
+
+    private function createClient(): Client
+    {
+        return Client::query()->create([
+            'nom' => 'Diallo',
+            'prenom' => 'Albar',
+            'telephone' => '+221770000001',
+            'source' => 'en_ligne',
+            'est_blackliste' => false,
+        ]);
+    }
+
+    private function createPendingPayment(): Paiement
+    {
+        $client = $this->createClient();
+        $reservation = Reservation::query()->create([
+            'client_id' => $client->id,
+            'date_reservation' => now()->addDay()->toDateString(),
+            'heure_debut' => '10:00',
+            'heure_fin' => '11:00',
+            'duree_totale_minutes' => 60,
+            'statut' => 'en_attente',
+            'source' => 'en_ligne',
+            'montant_total' => 15000,
+            'montant_acompte' => 5000,
+            'montant_reduction' => 0,
+            'montant_restant' => 10000,
+            'devise' => 'FCFA',
+        ]);
+
+        return Paiement::query()->create([
+            'reservation_id' => $reservation->id,
+            'client_id' => $client->id,
+            'numero_recu' => 'TEST-ML-001',
+            'type' => 'acompte',
+            'mode_paiement' => 'wave',
+            'montant' => 5000,
+            'devise' => 'FCFA',
+            'statut' => 'en_attente',
+            'date_paiement' => now(),
+            'recu_envoye' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
 ## Résumé

   - **WhatsappService** : extraction du canal WhatsApp vers un service dédié
   réutilisable (Twilio first, Cloud API fallback)
   - **Migration** : ajout `magic_link_token`, `magic_link_expires_at`,
   `session_token`, `session_expires_at` sur la table `clients`
   - **ClientMagicLinkService** : token single-use (hash SHA-256 en DB, brut
   uniquement dans le lien/cookie)
   - **SendMagicLinkNotification** : job dispatché après paiement confirmé, envoie
   l''URL via WhatsApp
   - **AuthenticateClientSession** : middleware cookie httpOnly → client résolu en
   DB
   - **ClientSessionController** : `POST /api/client/auth/magic-link`, `GET
   /api/client/session`, `DELETE /api/client/session`
   - **Idempotence** : `UPDATE WHERE statut != ''valide''` atomique dans
   `markPaymentAsPaid`

   ## Test plan

   - [x] 11 tests `MagicLinkTest` : token valide/expiré/rejoué/inconnu, validation,
   session avec/sans cookie chiffré, session expirée, logout + révocation DB, client
    blacklisté, dispatch job après paiement
   - [x] Suite complète : 78 passed, 1 skipped (SQLite `whereTime` limitation
   connue)
   - [x] Cookie extrait de l''endpoint `verify` et rejoué via
   `withUnencryptedCookies()` — même patron que les tests admin

   ## À faire post-merge (frontend)

   - Détecter `?magic_token=` dans l''URL → appeler `POST
   `withUnencryptedCookies()` — même patron que les tests admin