### PR TITLE
Feat/avis verifies

### DIFF
--- a/backend/app/Console/Commands/DispatchReviewInvitations.php
+++ b/backend/app/Console/Commands/DispatchReviewInvitations.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SendReviewInvitation;
+use App\Models\Reservation;
+use Illuminate\Console\Command;
+
+/**
+ * Trouve les reservations terminees depuis au moins 24h sans invitation
+ * deja envoyee et dispatche SendReviewInvitation pour chacune.
+ *
+ * Tourne en cron quotidien a 10h (console.php). Idempotent : review_invited_at
+ * garantit qu une reservation n est invitee qu une seule fois meme si le
+ * cron tourne plusieurs fois dans la journee.
+ *
+ * Usage :
+ *   php artisan reviews:dispatch-invitations
+ *   php artisan reviews:dispatch-invitations --dry-run
+ */
+class DispatchReviewInvitations extends Command
+{
+    protected $signature = 'reviews:dispatch-invitations {--dry-run : Affiche les reservations eligibles sans envoyer}';
+
+    protected $description = 'Envoie les invitations avis WhatsApp pour les reservations terminees depuis 24h.';
+
+    public function handle(): int
+    {
+        $reservations = Reservation::query()
+            ->with('client')
+            ->where('statut', 'terminee')
+            ->whereNull('review_invited_at')
+            ->whereDate('date_reservation', '<=', now()->subDay()->toDateString())
+            ->whereHas('client', fn ($q) => $q->whereNotNull('telephone'))
+            ->get();
+
+        $this->info("Reservations eligibles : {$reservations->count()}");
+
+        if ($this->option('dry-run')) {
+            foreach ($reservations as $reservation) {
+                $this->line("  [dry-run] #{$reservation->id} — {$reservation->client->prenom} {$reservation->client->nom} ({$reservation->date_reservation})");
+            }
+
+            return self::SUCCESS;
+        }
+
+        foreach ($reservations as $reservation) {
+            SendReviewInvitation::dispatch($reservation->id);
+        }
+
+        $this->info("Jobs dispatches : {$reservations->count()}");
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Http/Controllers/Api/Client/AvisController.php
+++ b/backend/app/Http/Controllers/Api/Client/AvisController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers\Api\Client;
+
+use App\Http\Controllers\Controller;
+use App\Models\AvisCoiffure;
+use App\Models\Reservation;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Avis verifies post-prestation (Phase 5 etape 3).
+ *
+ * Le token dans l URL provient du lien WhatsApp envoye 24h apres la fin
+ * de la reservation (job SendReviewInvitation). Il est single-use et expire
+ * apres 7 jours. L avis cree est marque verifie=true pour distinguer les
+ * avis clients reels des avis non verifies soumis librement via le catalogue.
+ */
+class AvisController extends Controller
+{
+    /**
+     * GET /api/client/avis/{token}
+     *
+     * Retourne les infos de prefill (prenom + coiffure_nom) pour la page
+     * d avis frontend. Ne revele pas de donnees sensibles (pas d email, pas
+     * de telephone, pas d historique).
+     */
+    public function prefill(string $token): JsonResponse
+    {
+        $reservation = $this->findByToken($token);
+
+        if (! $reservation) {
+            return response()->json(['message' => 'Lien invalide ou expiré.'], 404);
+        }
+
+        return response()->json([
+            'data' => [
+                'prenom' => $reservation->client->prenom,
+                'coiffure_nom' => $reservation->details->first()?->coiffure_nom ?? '',
+            ],
+        ]);
+    }
+
+    /**
+     * POST /api/client/avis/{token}
+     *
+     * Cree un avis verifie pour la reservation liee au token.
+     * Token consomme apres soumission (single-use).
+     */
+    public function store(Request $request, string $token): JsonResponse
+    {
+        $reservation = $this->findByToken($token);
+
+        if (! $reservation) {
+            return response()->json(['message' => 'Lien invalide ou expiré.'], 422);
+        }
+
+        // Un seul avis verifie par reservation.
+        $alreadyReviewed = AvisCoiffure::query()
+            ->where('reservation_id', $reservation->id)
+            ->where('verifie', true)
+            ->exists();
+
+        if ($alreadyReviewed) {
+            return response()->json(['message' => 'Vous avez déjà soumis un avis pour cette prestation.'], 422);
+        }
+
+        $data = $request->validate([
+            'note' => ['required', 'integer', 'min:1', 'max:5'],
+            'commentaire' => ['required', 'string', 'min:10', 'max:1000'],
+        ]);
+
+        $detail = $reservation->details->first();
+
+        AvisCoiffure::query()->create([
+            'coiffure_id' => $detail?->coiffure_id,
+            'client_id' => $reservation->client_id,
+            'reservation_id' => $reservation->id,
+            'nom_client' => $reservation->client->prenom . ' ' . $reservation->client->nom,
+            'note' => $data['note'],
+            'commentaire' => $data['commentaire'],
+            'verifie' => true,
+            'statut' => 'en_attente',
+        ]);
+
+        // Consomme le token pour qu il ne puisse pas etre rejoue.
+        $reservation->forceFill([
+            'review_token' => null,
+            'review_token_expires_at' => null,
+        ])->save();
+
+        return response()->json(['message' => 'Merci pour votre avis ! Il sera visible après modération.'], 201);
+    }
+
+    private function findByToken(string $token): ?Reservation
+    {
+        return Reservation::query()
+            ->with(['client', 'details'])
+            ->where('review_token', hash('sha256', $token))
+            ->where('review_token_expires_at', '>', now())
+            ->where('statut', 'terminee')
+            ->first();
+    }
+}

--- a/backend/app/Jobs/SendReviewInvitation.php
+++ b/backend/app/Jobs/SendReviewInvitation.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Reservation;
+use App\Services\WhatsappService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+
+/**
+ * Envoie l invitation a laisser un avis verifie pour une reservation terminee.
+ *
+ * Dispatche par la commande reviews:dispatch-invitations (cron quotidien 10h).
+ * Genere le token single-use, l enregistre en DB, puis envoie le lien
+ * via WhatsApp. review_invited_at est pose AVANT l envoi pour que meme un
+ * echec WhatsApp ne provoque pas un double-envoi au prochain passage du cron.
+ */
+class SendReviewInvitation implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public array $backoff = [10, 30, 60];
+
+    public function __construct(public readonly int $reservationId) {}
+
+    public function handle(WhatsappService $whatsapp): void
+    {
+        $reservation = Reservation::query()
+            ->with(['client', 'details'])
+            ->find($this->reservationId);
+
+        // Idempotence : si deja invite (race condition entre workers), on s arrete.
+        if (! $reservation || $reservation->review_invited_at !== null) {
+            return;
+        }
+
+        $client = $reservation->client;
+
+        if (! $client?->telephone) {
+            return;
+        }
+
+        $raw = Str::random(64);
+        $coiffureNom = $reservation->details->first()?->coiffure_nom ?? 'votre prestation';
+        $url = rtrim((string) config('app.frontend_url', config('app.url')), '/') . '/avis/' . $raw;
+
+        // Pose review_invited_at d abord : meme si l envoi WhatsApp echoue,
+        // le cron ne re-dispatche pas et le token reste utilisable 7 jours.
+        $reservation->forceFill([
+            'review_token' => hash('sha256', $raw),
+            'review_token_expires_at' => now()->addDays(7),
+            'review_invited_at' => now(),
+        ])->save();
+
+        $message = "Bonjour {$client->prenom} 👋\n\n"
+            . "Comment s'est passée votre prestation {$coiffureNom} ?\n\n"
+            . "Laissez un avis en 30 secondes ici :\n{$url}\n\n"
+            . "(Lien valable 7 jours)";
+
+        $whatsapp->send($client->telephone, $message, 'review_invitation');
+    }
+}

--- a/backend/database/migrations/2026_05_12_000003_add_review_token_to_reservations_table.php
+++ b/backend/database/migrations/2026_05_12_000003_add_review_token_to_reservations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservations', function (Blueprint $table): void {
+            // review_token : hash SHA-256 du token brut envoye dans le lien WhatsApp.
+            // Null = invitation pas encore envoyee OU token deja consomme apres soumission.
+            // review_invited_at : horodatage de l envoi — sert de verrou pour ne pas
+            // re-envoyer meme si le token a ete consomme (null = jamais invite).
+            $table->string('review_token', 128)->nullable()->unique()->after('notes');
+            $table->timestamp('review_token_expires_at')->nullable()->after('review_token');
+            $table->timestamp('review_invited_at')->nullable()->after('review_token_expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservations', function (Blueprint $table): void {
+            $table->dropColumn(['review_token', 'review_token_expires_at', 'review_invited_at']);
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -27,6 +27,7 @@ use App\Http\Controllers\Api\Admin\RegleFideliteController;
 use App\Http\Controllers\Api\Admin\VarianteCoiffureController;
 use App\Http\Controllers\Api\AnalyticsController;
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\Client\AvisController as ClientAvisController;
 use App\Http\Controllers\Api\Client\CatalogueController as ClientCatalogueController;
 use App\Http\Controllers\Api\Client\ClientSessionController;
 use App\Http\Controllers\Api\Client\PaymentController as ClientPaymentController;
@@ -60,6 +61,9 @@ Route::prefix('client')->name('client.')->group(function (): void {
     Route::post('/paiements/stripe/webhook', [ClientPaymentController::class, 'stripeWebhook'])->name('payments.stripe.webhook');
     Route::post('/paiements/paytech/confirmer', [ClientPaymentController::class, 'confirmPaytechReturn'])->middleware('throttle:20,1')->name('payments.paytech.confirm');
     Route::post('/paiements/paytech/ipn', [ClientPaymentController::class, 'paytechWebhook'])->name('payments.paytech.ipn');
+    // Avis verifies post-prestation (Phase 5 etape 3).
+    Route::get('/avis/{token}', [ClientAvisController::class, 'prefill'])->name('avis.prefill');
+    Route::post('/avis/{token}', [ClientAvisController::class, 'store'])->middleware('throttle:5,1')->name('avis.store');
 });
 
 Route::prefix('auth')->group(function (): void {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -46,7 +46,6 @@ Route::get('/reservations/disponibilites', ClientReservationAvailabilityControll
 Route::prefix('client')->name('client.')->group(function (): void {
     Route::get('/catalogue', [ClientCatalogueController::class, 'index'])->name('catalogue.index');
     Route::get('/catalogue/{coiffure}', [ClientCatalogueController::class, 'show'])->name('catalogue.show');
-    Route::post('/catalogue/{coiffure}/avis', [ClientCatalogueController::class, 'storeAvis'])->middleware('throttle:10,1')->name('catalogue.avis.store');
     // Lookup tel international (Phase 5 etape 1).
     Route::get('/lookup', [ClientCatalogueController::class, 'lookup'])->middleware('throttle:5,1')->name('lookup');
     // Magic link + session client (Phase 5 etape 2).

--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -1,8 +1,15 @@
 <?php
 
+use App\Console\Commands\DispatchReviewInvitations;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// Cron quotidien a 10h : envoie les invitations avis WhatsApp pour les
+// reservations terminees la veille. Le worker queue Redis doit tourner
+// en parallele pour consommer les jobs dispatches.
+Schedule::command(DispatchReviewInvitations::class)->dailyAt('10:00');

--- a/backend/tests/Feature/Client/AvisVerifieTest.php
+++ b/backend/tests/Feature/Client/AvisVerifieTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Tests\Feature\Client;
+
+use App\Console\Commands\DispatchReviewInvitations;
+use App\Jobs\SendReviewInvitation;
+use App\Models\AvisCoiffure;
+use App\Models\CategorieCoiffure;
+use App\Models\Client;
+use App\Models\Coiffure;
+use App\Models\DetailReservation;
+use App\Models\Reservation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+/**
+ * Tests d integration Phase 5 etape 3 : avis verifies post-prestation.
+ *
+ * Couvre :
+ * - GET /avis/{token} : prefill valide, token invalide, token expire
+ * - POST /avis/{token} : creation avis verifie, double soumission, token invalide,
+ *   token expire, validation note/commentaire, token consomme apres soumission
+ * - Command reviews:dispatch-invitations : dispatche les jobs pour les
+ *   reservations eligibles, ignore les deja invitees
+ */
+class AvisVerifieTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -----------------------------------------------------------------
+    // GET /api/client/avis/{token} — prefill
+    // -----------------------------------------------------------------
+
+    public function test_prefill_retourne_prenom_et_coiffure(): void
+    {
+        $reservation = $this->createTermineeReservation();
+        $rawToken = $this->setReviewToken($reservation);
+
+        $response = $this->getJson("/api/client/avis/{$rawToken}");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.prenom', $reservation->client->prenom);
+        $response->assertJsonPath('data.coiffure_nom', 'Tresses box braids');
+    }
+
+    public function test_prefill_token_inconnu_retourne_404(): void
+    {
+        $response = $this->getJson('/api/client/avis/' . str_repeat('x', 64));
+
+        $response->assertStatus(404);
+    }
+
+    public function test_prefill_token_expire_retourne_404(): void
+    {
+        $reservation = $this->createTermineeReservation();
+        $rawToken = $this->setReviewToken($reservation, expiredAt: true);
+
+        $response = $this->getJson("/api/client/avis/{$rawToken}");
+
+        $response->assertStatus(404);
+    }
+
+    // -----------------------------------------------------------------
+    // POST /api/client/avis/{token} — soumission
+    // -----------------------------------------------------------------
+
+    public function test_store_cree_un_avis_verifie_et_consomme_le_token(): void
+    {
+        $reservation = $this->createTermineeReservation();
+        $rawToken = $this->setReviewToken($reservation);
+
+        $response = $this->postJson("/api/client/avis/{$rawToken}", [
+            'note' => 5,
+            'commentaire' => 'Tres bonne prestation, je reviendrai.',
+        ]);
+
+        $response->assertStatus(201);
+
+        // Avis cree avec verifie=true.
+        $avis = AvisCoiffure::query()->where('reservation_id', $reservation->id)->first();
+        $this->assertNotNull($avis);
+        $this->assertTrue($avis->verifie);
+        $this->assertSame('en_attente', $avis->statut);
+        $this->assertSame(5, $avis->note);
+
+        // Token consomme en DB.
+        $this->assertNull($reservation->fresh()->review_token);
+    }
+
+    public function test_store_token_inconnu_retourne_422(): void
+    {
+        $response = $this->postJson('/api/client/avis/' . str_repeat('x', 64), [
+            'note' => 4,
+            'commentaire' => 'Super prestation du salon.',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_store_token_expire_retourne_422(): void
+    {
+        $reservation = $this->createTermineeReservation();
+        $rawToken = $this->setReviewToken($reservation, expiredAt: true);
+
+        $response = $this->postJson("/api/client/avis/{$rawToken}", [
+            'note' => 4,
+            'commentaire' => 'Super prestation du salon.',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_double_soumission_retourne_422(): void
+    {
+        $reservation = $this->createTermineeReservation();
+        $rawToken = $this->setReviewToken($reservation);
+
+        // Premier avis.
+        $this->postJson("/api/client/avis/{$rawToken}", [
+            'note' => 5,
+            'commentaire' => 'Tres bonne prestation, je reviendrai.',
+        ])->assertStatus(201);
+
+        // Deuxieme tentative avec un nouveau token (cas ou quelqu un essaie de
+        // soumettre un second avis verifie sur la meme reservation).
+        $rawToken2 = $this->setReviewToken($reservation);
+        $response = $this->postJson("/api/client/avis/{$rawToken2}", [
+            'note' => 1,
+            'commentaire' => 'Finalement pas si bien que ca.',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_validation_note_et_commentaire(): void
+    {
+        $reservation = $this->createTermineeReservation();
+        $rawToken = $this->setReviewToken($reservation);
+
+        // Note hors intervalle.
+        $this->postJson("/api/client/avis/{$rawToken}", [
+            'note' => 6,
+            'commentaire' => 'Ok',
+        ])->assertStatus(422)->assertJsonValidationErrors(['note']);
+
+        // Commentaire trop court.
+        $this->postJson("/api/client/avis/{$rawToken}", [
+            'note' => 4,
+            'commentaire' => 'Court',
+        ])->assertStatus(422)->assertJsonValidationErrors(['commentaire']);
+    }
+
+    // -----------------------------------------------------------------
+    // Command reviews:dispatch-invitations
+    // -----------------------------------------------------------------
+
+    public function test_command_dispatche_les_jobs_pour_reservations_eligibles(): void
+    {
+        Bus::fake();
+
+        // Eligible : terminee, date hier, pas encore invitee.
+        $eligible = $this->createTermineeReservation(daysAgo: 1);
+
+        // Non eligible : terminee mais deja invitee.
+        $dejaInvitee = $this->createTermineeReservation(daysAgo: 2);
+        $dejaInvitee->forceFill(['review_invited_at' => now()])->save();
+
+        // Non eligible : pas encore terminee.
+        $enAttente = $this->createTermineeReservation(daysAgo: 1);
+        $enAttente->forceFill(['statut' => 'confirmee'])->save();
+
+        $this->artisan(DispatchReviewInvitations::class)->assertSuccessful();
+
+        Bus::assertDispatched(SendReviewInvitation::class, fn ($job) => $job->reservationId === $eligible->id);
+        Bus::assertNotDispatched(SendReviewInvitation::class, fn ($job) => $job->reservationId === $dejaInvitee->id);
+        Bus::assertNotDispatched(SendReviewInvitation::class, fn ($job) => $job->reservationId === $enAttente->id);
+    }
+
+    public function test_command_dry_run_ne_dispatche_rien(): void
+    {
+        Bus::fake();
+
+        $this->createTermineeReservation(daysAgo: 1);
+
+        $this->artisan(DispatchReviewInvitations::class, ['--dry-run' => true])->assertSuccessful();
+
+        Bus::assertNothingDispatched();
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static int $seq = 0;
+
+    private function createTermineeReservation(int $daysAgo = 1): Reservation
+    {
+        $categorie = CategorieCoiffure::query()->firstOrCreate(
+            ['nom' => 'Tresses'],
+            ['actif' => true],
+        );
+
+        $coiffure = Coiffure::query()->firstOrCreate(
+            ['categorie_coiffure_id' => $categorie->id, 'nom' => 'Tresses box braids'],
+            ['actif' => true],
+        );
+
+        $telephone = '+221770' . str_pad(++self::$seq, 6, '0', STR_PAD_LEFT);
+
+        $client = Client::query()->create([
+            'nom' => 'Diallo',
+            'prenom' => 'Fatou',
+            'telephone' => $telephone,
+            'source' => 'en_ligne',
+            'est_blackliste' => false,
+        ]);
+
+        $reservation = Reservation::query()->create([
+            'client_id' => $client->id,
+            'date_reservation' => now()->subDays($daysAgo)->toDateString(),
+            'heure_debut' => '10:00',
+            'heure_fin' => '12:00',
+            'duree_totale_minutes' => 120,
+            'statut' => 'terminee',
+            'source' => 'en_ligne',
+            'montant_total' => 20000,
+            'montant_acompte' => 5000,
+            'montant_reduction' => 0,
+            'montant_restant' => 15000,
+            'devise' => 'FCFA',
+        ]);
+
+        DetailReservation::query()->create([
+            'reservation_id' => $reservation->id,
+            'coiffure_id' => $coiffure->id,
+            'coiffure_nom' => 'Tresses box braids',
+            'variante_nom' => 'Petites tresses',
+            'prix_unitaire' => 20000,
+            'duree_minutes' => 120,
+            'quantite' => 1,
+            'montant_options' => 0,
+            'montant_total' => 20000,
+            'ordre' => 1,
+        ]);
+
+        return $reservation->load(['client', 'details']);
+    }
+
+    /**
+     * Pose un review_token sur la reservation et retourne le token brut.
+     */
+    private function setReviewToken(Reservation $reservation, bool $expiredAt = false): string
+    {
+        $raw = str_repeat('t', 64);
+        $reservation->forceFill([
+            'review_token' => hash('sha256', $raw),
+            'review_token_expires_at' => $expiredAt ? now()->subMinute() : now()->addDays(7),
+            'review_invited_at' => now(),
+        ])->save();
+
+        return $raw;
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 // du parcours principal et le visiteur du catalogue les charge de toute facon.
 import LoginPage from './pages/LoginPage'
 import ClientHomePage from './features/client/ClientHomePage'
+import AvisPage from './features/client/AvisPage'
 import RequireAuth from './features/auth/RequireAuth'
 
 // Routes admin (I9) : code-split via React.lazy + Suspense.
@@ -84,6 +85,7 @@ function App() {
     <Routes>
       <Route path="/" element={<ClientHomePage />} />
       <Route path="/client" element={<ClientHomePage />} />
+      <Route path="/avis/:token" element={<AvisPage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />
       <Route path="/admin/dashboard" element={<AdminRoute><AdminDashboardPage /></AdminRoute>} />

--- a/frontend/src/features/client/AvisPage.tsx
+++ b/frontend/src/features/client/AvisPage.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Star } from 'lucide-react'
+import { getAvisPrefill, submitVerifiedAvis } from './client.api'
+import type { AvisPrefill } from './client.types'
+
+type PageState = 'loading' | 'form' | 'success' | 'error'
+
+export default function AvisPage() {
+  const { token } = useParams<{ token: string }>()
+
+  const [pageState, setPageState] = useState<PageState>('loading')
+  const [prefill, setPrefill] = useState<AvisPrefill | null>(null)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const [note, setNote] = useState(0)
+  const [hovered, setHovered] = useState(0)
+  const [commentaire, setCommentaire] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({})
+
+  useEffect(() => {
+    if (!token) {
+      setErrorMessage('Lien invalide.')
+      setPageState('error')
+      return
+    }
+
+    getAvisPrefill(token)
+      .then((data) => {
+        setPrefill(data)
+        setPageState('form')
+      })
+      .catch(() => {
+        setErrorMessage('Ce lien est invalide ou a expiré. Merci de vérifier le lien WhatsApp reçu.')
+        setPageState('error')
+      })
+  }, [token])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!token) return
+
+    setFieldErrors({})
+
+    if (note === 0) {
+      setFieldErrors({ note: ['Veuillez sélectionner une note.'] })
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await submitVerifiedAvis(token, { note, commentaire })
+      setPageState('success')
+    } catch (err: unknown) {
+      const axiosErr = err as { response?: { status?: number; data?: { errors?: Record<string, string[]>; message?: string } } }
+      const status = axiosErr?.response?.status
+      const data = axiosErr?.response?.data
+
+      if (status === 422 && data?.errors) {
+        setFieldErrors(data.errors)
+      } else if (status === 422 && data?.message) {
+        setErrorMessage(data.message)
+        setPageState('error')
+      } else {
+        setErrorMessage('Une erreur est survenue. Veuillez réessayer.')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (pageState === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#faf9fa]">
+        <p className="text-sm font-semibold text-gray-500">Chargement...</p>
+      </div>
+    )
+  }
+
+  if (pageState === 'error') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#faf9fa] px-4">
+        <div className="w-full max-w-md rounded-2xl border border-gray-100 bg-white p-8 shadow-sm text-center">
+          <p className="text-4xl mb-4">🙁</p>
+          <h1 className="text-xl font-black text-gray-900 mb-2">Lien non valide</h1>
+          <p className="text-sm text-gray-500">{errorMessage}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (pageState === 'success') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#faf9fa] px-4">
+        <div className="w-full max-w-md rounded-2xl border border-gray-100 bg-white p-8 shadow-sm text-center">
+          <p className="text-5xl mb-4">🌸</p>
+          <h1 className="text-xl font-black text-gray-900 mb-2">Merci pour votre avis !</h1>
+          <p className="text-sm text-gray-500">
+            Votre avis sera visible sur la page du salon après validation par notre équipe.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const displayNote = hovered > 0 ? hovered : note
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#faf9fa] px-4 py-10">
+      <div className="w-full max-w-md rounded-2xl border border-gray-100 bg-white p-8 shadow-sm">
+        {/* En-tête */}
+        <div className="mb-6 text-center">
+          <p className="text-3xl mb-2">✂️</p>
+          <h1 className="text-xl font-black text-gray-900">
+            {prefill?.prenom ? `Merci ${prefill.prenom} !` : 'Votre avis'}
+          </h1>
+          {prefill?.coiffure_nom && (
+            <p className="mt-1 text-sm text-gray-500">
+              Prestation : <span className="font-semibold text-gray-700">{prefill.coiffure_nom}</span>
+            </p>
+          )}
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* Étoiles */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              Votre note <span className="text-[#f31976]">*</span>
+            </label>
+            <div
+              className="flex gap-1"
+              onMouseLeave={() => setHovered(0)}
+            >
+              {[1, 2, 3, 4, 5].map((star) => (
+                <button
+                  key={star}
+                  type="button"
+                  aria-label={`${star} étoile${star > 1 ? 's' : ''}`}
+                  className="p-1 transition-transform hover:scale-110 focus:outline-none"
+                  onMouseEnter={() => setHovered(star)}
+                  onClick={() => setNote(star)}
+                >
+                  <Star
+                    className="h-8 w-8 transition-colors"
+                    fill={star <= displayNote ? '#f31976' : 'none'}
+                    stroke={star <= displayNote ? '#f31976' : '#d1d5db'}
+                    strokeWidth={1.5}
+                  />
+                </button>
+              ))}
+            </div>
+            {fieldErrors.note && (
+              <p className="mt-1 text-xs text-red-500">{fieldErrors.note[0]}</p>
+            )}
+          </div>
+
+          {/* Commentaire */}
+          <div>
+            <label htmlFor="commentaire" className="block text-sm font-semibold text-gray-700 mb-1.5">
+              Votre commentaire <span className="text-[#f31976]">*</span>
+            </label>
+            <textarea
+              id="commentaire"
+              rows={4}
+              value={commentaire}
+              onChange={(e) => setCommentaire(e.target.value)}
+              placeholder="Décrivez votre expérience (minimum 10 caractères)..."
+              className="w-full rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-800 placeholder:text-gray-400 focus:border-[#f31976] focus:outline-none focus:ring-2 focus:ring-[#f31976]/20 resize-none"
+            />
+            <div className="flex items-center justify-between mt-1">
+              {fieldErrors.commentaire ? (
+                <p className="text-xs text-red-500">{fieldErrors.commentaire[0]}</p>
+              ) : (
+                <span />
+              )}
+              <p className="text-xs text-gray-400 tabular-nums">{commentaire.length}/1000</p>
+            </div>
+          </div>
+
+          {/* Bouton */}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded-full bg-[#f31976] py-3 text-sm font-black text-white shadow-sm transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting ? 'Envoi...' : 'Envoyer mon avis'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/client/ClientHomePage.tsx
+++ b/frontend/src/features/client/ClientHomePage.tsx
@@ -19,10 +19,8 @@ import {
   Phone,
   Scissors,
   Search,
-  Send,
   ShieldCheck,
   Sparkles,
-  Star,
   User,
   Users,
   X,
@@ -35,7 +33,6 @@ import heroImage from '../../assets/hero.jpg'
 import {
   confirmPaytechReturn,
   confirmStripeCheckout,
-  createClientCoiffureReview,
   createClientReservation,
   getClientAvailability,
   getClientCatalogue,
@@ -69,7 +66,6 @@ import type {
   ClientPromotion,
   ClientReservation,
   ClientReservationPayload,
-  ClientCoiffureReviewPayload,
   ClientSession,
 } from './client.types'
 
@@ -85,14 +81,6 @@ type BookingForm = {
   code_promo: string
   notes: string
   paymentMethod: ClientPaymentMethod
-}
-
-type ReviewForm = {
-  nom_client: string
-  telephone: string
-  email: string
-  note: number
-  commentaire: string
 }
 
 type SubmitState = {
@@ -163,14 +151,6 @@ function createBookingForm(coiffure?: ClientCoiffure): BookingForm {
   }
 }
 
-const emptyReviewForm = (): ReviewForm => ({
-  nom_client: '',
-  telephone: '',
-  email: '',
-  note: 5,
-  commentaire: '',
-})
-
 function extractApiError(error: unknown) {
   if (axios.isAxiosError(error)) {
     const payload = error.response?.data as {
@@ -215,9 +195,6 @@ function ClientHomePage() {
   const [availabilityError, setAvailabilityError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [submitState, setSubmitState] = useState<SubmitState>(null)
-  const [reviewForm, setReviewForm] = useState<ReviewForm>(() => emptyReviewForm())
-  const [reviewSubmitting, setReviewSubmitting] = useState(false)
-  const [reviewState, setReviewState] = useState<SubmitState>(null)
   const [pageNotice, setPageNotice] = useState<SubmitState>(null)
   const [submittedReservation, setSubmittedReservation] = useState<ClientReservation | null>(null)
   const [clientSession, setClientSession] = useState<ClientSession | null>(null)
@@ -491,13 +468,6 @@ function ClientHomePage() {
     }))
   }
 
-  function updateReviewField<K extends keyof ReviewForm>(key: K, value: ReviewForm[K]) {
-    setReviewForm((current) => ({
-      ...current,
-      [key]: value,
-    }))
-  }
-
   // useCallback pour stabiliser les references entre re-renders et permettre
   // au memo de CoiffureCard de fonctionner (sinon nouveau callback a chaque
   // render -> memo casse -> 8 cartes re-rendent a chaque frappe). Pareil
@@ -524,8 +494,6 @@ function ClientHomePage() {
   function closeDetails() {
     setSelectedCoiffure(null)
     setSubmitState(null)
-    setReviewState(null)
-    setReviewForm(emptyReviewForm())
     setSubmittedReservation(null)
     setAvailability(null)
     setAvailabilityLoading(false)
@@ -546,8 +514,6 @@ function ClientHomePage() {
     setSelectedCoiffure(coiffure)
     setBookingForm(createBookingForm(coiffure))
     setSubmitState(null)
-    setReviewState(null)
-    setReviewForm(emptyReviewForm())
     setSubmittedReservation(null)
     setAvailability(null)
     setAvailabilityLoading(true)
@@ -567,44 +533,6 @@ function ClientHomePage() {
       setModalLoading(false)
     }
   }, [])
-
-  async function handleReviewSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-
-    if (!selectedCoiffure) {
-      return
-    }
-
-    if (reviewForm.nom_client.trim() === '' || reviewForm.commentaire.trim().length < 8) {
-      setReviewState({ type: 'error', message: 'Ajoutez votre nom et un commentaire plus detaille.' })
-      return
-    }
-
-    const payload: ClientCoiffureReviewPayload = {
-      nom_client: reviewForm.nom_client.trim(),
-      telephone: reviewForm.telephone.trim() === '' ? null : reviewForm.telephone.trim(),
-      email: reviewForm.email.trim() === '' ? null : reviewForm.email.trim(),
-      note: reviewForm.note,
-      commentaire: reviewForm.commentaire.trim(),
-    }
-
-    setReviewSubmitting(true)
-    setReviewState(null)
-
-    try {
-      const response = await createClientCoiffureReview(selectedCoiffure.id, payload)
-      setReviewState({ type: 'success', message: response.message ?? 'Merci pour votre avis.' })
-      setReviewForm(emptyReviewForm())
-
-      if (response.data.statut === 'approuve') {
-        setSelectedCoiffure(await getClientCoiffureDetails(selectedCoiffure.id))
-      }
-    } catch (error) {
-      setReviewState({ type: 'error', message: extractApiError(error) })
-    } finally {
-      setReviewSubmitting(false)
-    }
-  }
 
   async function handleReservationSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -1430,79 +1358,6 @@ function ClientHomePage() {
                 {bookingForm.paymentMethod === 'carte_bancaire' ? 'Continuer vers Stripe' : 'Continuer vers PayTech'}
               </button>
             </form>
-
-            <section className="border-t border-slate-100 bg-white p-4 sm:p-6 lg:col-span-2">
-              <form onSubmit={handleReviewSubmit} className="rounded-3xl bg-slate-950 p-4 text-white">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="text-sm font-black">Ajouter votre commentaire</p>
-                    <p className="mt-1 text-xs font-bold text-white/55">Votre avis aide les prochaines clientes a choisir.</p>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    {Array.from({ length: 5 }, (_, index) => {
-                      const note = index + 1
-
-                      return (
-                        <button
-                          key={note}
-                          type="button"
-                          onClick={() => updateReviewField('note', note)}
-                          className="grid h-9 w-9 place-items-center rounded-full bg-white/10 text-[#f59e0b]"
-                          aria-label={`${note} etoiles`}
-                        >
-                          <Star className={`h-5 w-5 ${note <= reviewForm.note ? 'fill-[#f59e0b]' : 'fill-none text-white/40'}`} />
-                        </button>
-                      )
-                    })}
-                  </div>
-                </div>
-                <div className="mt-3 grid grid-cols-2 gap-3">
-                  <input
-                    value={reviewForm.nom_client}
-                    onChange={(event) => updateReviewField('nom_client', event.target.value)}
-                    placeholder="Votre nom"
-                    required
-                    className="h-11 rounded-2xl border border-white/10 bg-white/10 px-3 text-sm font-bold text-white outline-none placeholder:text-white/45 focus:border-white/40"
-                  />
-                  <input
-                    value={reviewForm.telephone}
-                    onChange={(event) => updateReviewField('telephone', event.target.value)}
-                    placeholder="Telephone"
-                    className="h-11 rounded-2xl border border-white/10 bg-white/10 px-3 text-sm font-bold text-white outline-none placeholder:text-white/45 focus:border-white/40"
-                  />
-                </div>
-                <div className="mt-3 grid gap-3 sm:grid-cols-[0.7fr_1.3fr]">
-                  <input
-                    type="email"
-                    value={reviewForm.email}
-                    onChange={(event) => updateReviewField('email', event.target.value)}
-                    placeholder="Email optionnel"
-                    className="h-11 rounded-2xl border border-white/10 bg-white/10 px-3 text-sm font-bold text-white outline-none placeholder:text-white/45 focus:border-white/40"
-                  />
-                  <textarea
-                    value={reviewForm.commentaire}
-                    onChange={(event) => updateReviewField('commentaire', event.target.value)}
-                    placeholder="Votre experience avec cette coiffure"
-                    required
-                    rows={2}
-                    className="min-h-11 rounded-2xl border border-white/10 bg-white/10 px-3 py-3 text-sm font-bold text-white outline-none placeholder:text-white/45 focus:border-white/40"
-                  />
-                </div>
-                {reviewState ? (
-                  <p className={`mt-3 rounded-2xl px-3 py-2 text-xs font-bold ${reviewState.type === 'success' ? 'bg-emerald-400/15 text-emerald-100' : 'bg-rose-400/15 text-rose-100'}`}>
-                    {reviewState.message}
-                  </p>
-                ) : null}
-                <button
-                  type="submit"
-                  disabled={reviewSubmitting}
-                  className="mt-3 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-2xl bg-white px-4 py-3 text-sm font-black text-[#d80f63] disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {reviewSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-                  Publier mon avis
-                </button>
-              </form>
-            </section>
           </div>
         </div>
       ) : null}

--- a/frontend/src/features/client/client.api.ts
+++ b/frontend/src/features/client/client.api.ts
@@ -1,6 +1,8 @@
 import { apiAssetUrl } from '../../lib/apiAssets'
 import { apiClient } from '../../lib/apiClient'
 import type {
+  AvisPrefill,
+  AvisVerifiePayload,
   ClientApiItem,
   ClientAvailability,
   ClientCatalogue,
@@ -128,6 +130,20 @@ export async function getClientSession() {
 
 export async function logoutClientSession() {
   await apiClient.delete('/client/session')
+}
+
+// -----------------------------------------------------------------
+// Phase 5 etape 3 : avis verifies post-prestation
+// -----------------------------------------------------------------
+
+export async function getAvisPrefill(token: string) {
+  const response = await apiClient.get<ClientApiItem<AvisPrefill>>(`/client/avis/${token}`)
+  return response.data.data
+}
+
+export async function submitVerifiedAvis(token: string, payload: AvisVerifiePayload) {
+  const response = await apiClient.post<{ message: string }>(`/client/avis/${token}`, payload)
+  return response.data
 }
 
 /**

--- a/frontend/src/features/client/client.types.ts
+++ b/frontend/src/features/client/client.types.ts
@@ -230,3 +230,14 @@ export type ClientMagicLinkVerifyResponse = {
   message: string
   data: ClientSession
 }
+
+// Phase 5 etape 3 : avis verifies post-prestation via lien WhatsApp.
+export type AvisPrefill = {
+  prenom: string
+  coiffure_nom: string
+}
+
+export type AvisVerifiePayload = {
+  note: number
+  commentaire: string
+}


### PR DESCRIPTION
 Backend — route retirée : POST /api/client/catalogue/{coiffure}/avis

  Frontend — nettoyage complet :
  - Type ReviewForm + fonction emptyReviewForm
  - States reviewForm, reviewSubmitting, reviewState
  - Fonctions updateReviewField + handleReviewSubmit
  - Tout le formulaire JSX (étoiles, champs nom/téléphone/email/commentaire, bouton
  "Publier mon avis")

  Désormais, 100% des avis sont vérifiés — seules les clientes qui ont terminé une
  prestation et reçu le lien WhatsApp peuvent en soumettre un.