### PR TITLE
fix(images): proxy Vite pour /storage + correction APP_URL port 8000

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,6 +23,13 @@ export default defineConfig({
         target: 'http://localhost:8000',
         changeOrigin: false, // garde l Origin du navigateur pour les checks CORS Laravel
       },
+      // Proxy les assets uploadés (images coiffures) : Storage::url() génère
+      // des URLs http://localhost:8000/storage/... que apiAssetUrl réécrit en
+      // http://localhost:5173/storage/... — sans ce proxy Vite renverrait 404.
+      '/storage': {
+        target: 'http://localhost:8000',
+        changeOrigin: false,
+      },
     },
   },
 


### PR DESCRIPTION
Sans proxy /storage, Vite renvoyait 404 sur les images uploadees : apiAssetUrl reecrivait http://localhost/storage/... en http://localhost:5173/storage/... et le serveur Vite dev ne proxifie que /api. APP_URL corrige dans .env pour que Storage::url() genere des URLs avec le bon port (8000).