### PR TITLE
fix(ui): suppression message NabooPay + correction graphe depenses

### DIFF
--- a/frontend/src/features/admin/reports/ReportsPage.tsx
+++ b/frontend/src/features/admin/reports/ReportsPage.tsx
@@ -141,11 +141,12 @@ function RevenueExpenseChart({
   revenue: ReportSeriesPoint[]
   expenses: ReportSeriesPoint[]
 }) {
-  const points = revenue.map((point, index) => ({
+  const expenseByKey = Object.fromEntries(expenses.map((e) => [e.key, e.value]))
+  const points = revenue.map((point) => ({
     key: point.key,
     label: point.label,
     revenue: point.value,
-    expense: expenses[index]?.value ?? 0,
+    expense: expenseByKey[point.key] ?? 0,
   }))
   const max = Math.max(...points.flatMap((point) => [point.revenue, point.expense]), 1)
 

--- a/frontend/src/features/client/ClientHomePage.tsx
+++ b/frontend/src/features/client/ClientHomePage.tsx
@@ -1665,15 +1665,6 @@ function ClientHomePage() {
                   })}
                 </div>
 
-                {bookingForm.paymentMethod !== 'carte_bancaire' ? (
-                  <div className="mt-4 rounded-3xl bg-[#fff0f6] p-4 text-sm font-bold text-[#b01258]">
-                    Vous serez redirigee vers NabooPay pour payer par {selectedPaymentMethod?.label}. Le paiement sera valide automatiquement par webhook.
-                  </div>
-                ) : (
-                  <div className="mt-4 rounded-3xl bg-[#fff0f6] p-4 text-sm font-bold text-[#b01258]">
-                    Vous serez redirigee vers NabooPay pour payer par carte bancaire. Le paiement sera valide automatiquement au retour ou par webhook.
-                  </div>
-                )}
               </div>
 
               <div className="mt-6 rounded-3xl bg-slate-950 p-5 text-white">
@@ -1731,7 +1722,7 @@ function ClientHomePage() {
                 className="mt-5 flex min-h-14 w-full items-center justify-center gap-2 rounded-2xl bg-[#f31976] px-5 py-4 text-base font-black text-white shadow-lg transition disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {submitting ? <Loader2 className="h-5 w-5 animate-spin" /> : <CalendarCheck className="h-5 w-5" />}
-                Continuer vers NabooPay
+                Confirmer et payer l'acompte
               </button>
             </form>
           </div>


### PR DESCRIPTION
- Retire le bloc informatif NabooPay sous les moyens de paiement (inutile cote cliente)
- Renomme le bouton de soumission en 'Confirmer et payer l acompte'
- Graphe Revenus vs Depenses : matching par key de periode au lieu de l index pour garantir l alignement meme si les series ont des longueurs differentes