### PR TITLE
fix(nginx): ^~ sur /storage/ pour eviter que le regex image ecrase l'…

### DIFF
--- a/infra/docker/nginx/prod.conf
+++ b/infra/docker/nginx/prod.conf
@@ -57,10 +57,10 @@ server {
     }
 
     # ── Fichiers stockage (images uploadées) ──────────────────────────────────
-    # Cloudflare met ces fichiers en cache avec son propre TTL.
-    # stale-while-revalidate laisse nginx servir le fichier périmé pendant
-    # que Cloudflare rafraîchit en arrière-plan → zéro latence perceptible.
-    location /storage/ {
+    # ^~ : empêche les blocs regex ~* (images statiques ci-dessous) de prendre
+    # la priorité sur ce préfixe. Sans ^~, nginx choisit le regex ~* \.(jpg|webp...)$
+    # qui ne connaît pas l'alias /storage/ → 404 sur toutes les images uploadées.
+    location ^~ /storage/ {
         alias /var/www/html/storage/app/public/;
         try_files $uri =404;
         add_header Cache-Control "public, max-age=604800, stale-while-revalidate=86400" always;


### PR DESCRIPTION
…alias

Le bloc ~* \.(jpg|webp|png...)$ ajout lors de l'optimisation prenait la priorite sur location /storage/ → nginx cherchait les images uploadees dans /usr/share/nginx/html/storage/ (inexistant) → 404 → images blanches.