### PR TITLE
feat(promo): popup code promo sur la page cliente

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/CodePromoController.php
+++ b/backend/app/Http/Controllers/Api/Admin/CodePromoController.php
@@ -101,7 +101,17 @@ class CodePromoController extends Controller
             'limite_utilisation' => ['nullable', 'integer', 'min:1'],
             'nombre_utilisations' => ['sometimes', 'integer', 'min:0'],
             'actif' => ['sometimes', 'boolean'],
+            'afficher_popup' => ['sometimes', 'boolean'],
         ]);
+
+        // Un seul popup peut être actif à la fois : on désactive les autres
+        // dès qu'un nouveau est activé pour éviter les doublons côté client.
+        if (! empty($data['afficher_popup'])) {
+            CodePromo::query()
+                ->when($codePromo, fn ($q) => $q->where('id', '!=', $codePromo->id))
+                ->where('afficher_popup', true)
+                ->update(['afficher_popup' => false]);
+        }
 
         $typeReduction = $data['type_reduction'] ?? $codePromo?->type_reduction;
         $valeur = array_key_exists('valeur', $data) ? (float) $data['valeur'] : (float) ($codePromo?->valeur ?? 0);

--- a/backend/app/Http/Controllers/Api/Client/CatalogueController.php
+++ b/backend/app/Http/Controllers/Api/Client/CatalogueController.php
@@ -474,4 +474,33 @@ class CatalogueController extends Controller
             'prenom' => $client?->prenom,
         ]);
     }
+
+    /**
+     * GET /api/client/promo-active
+     *
+     * Retourne le code promo marqué afficher_popup=true s'il est valide,
+     * null sinon. Endpoint public, sans authentification.
+     * Utilisé par le frontend pour afficher le popup promotionnel au premier chargement.
+     */
+    public function promoActive(): JsonResponse
+    {
+        $promo = CodePromo::query()
+            ->where('actif', true)
+            ->where('afficher_popup', true)
+            ->where(function ($query): void {
+                $query->whereNull('date_debut')->orWhere('date_debut', '<=', now());
+            })
+            ->where(function ($query): void {
+                $query->whereNull('date_fin')->orWhere('date_fin', '>=', now());
+            })
+            ->where(function ($query): void {
+                // Exclure les codes dont la limite d'utilisation est atteinte
+                $query->whereNull('limite_utilisation')
+                    ->orWhereColumn('nombre_utilisations', '<', 'limite_utilisation');
+            })
+            ->select(['id', 'code', 'nom', 'type_reduction', 'valeur'])
+            ->first();
+
+        return response()->json(['data' => $promo]);
+    }
 }

--- a/backend/app/Models/CodePromo.php
+++ b/backend/app/Models/CodePromo.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Model;
     'limite_utilisation',
     'nombre_utilisations',
     'actif',
+    'afficher_popup',
 ])]
 class CodePromo extends Model
 {
@@ -35,6 +36,7 @@ class CodePromo extends Model
             'limite_utilisation' => 'integer',
             'nombre_utilisations' => 'integer',
             'actif' => 'boolean',
+            'afficher_popup' => 'boolean',
         ];
     }
 }

--- a/backend/database/migrations/2026_05_18_000002_add_afficher_popup_to_codes_promo.php
+++ b/backend/database/migrations/2026_05_18_000002_add_afficher_popup_to_codes_promo.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('codes_promo', function (Blueprint $table): void {
+            // Un seul code promo peut être affiché en popup sur la page cliente.
+            // L'admin active le flag sur un code → la page cliente affiche le popup
+            // au premier chargement (sessionStorage empêche l'affichage répété).
+            $table->boolean('afficher_popup')->default(false)->after('actif');
+            $table->index('afficher_popup');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('codes_promo', function (Blueprint $table): void {
+            $table->dropIndex(['afficher_popup']);
+            $table->dropColumn('afficher_popup');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -46,6 +46,7 @@ Route::get('/reservations/disponibilites', ClientReservationAvailabilityControll
 Route::prefix('client')->name('client.')->group(function (): void {
     Route::get('/catalogue', [ClientCatalogueController::class, 'index'])->name('catalogue.index');
     Route::get('/catalogue/{coiffure}', [ClientCatalogueController::class, 'show'])->name('catalogue.show');
+    Route::get('/promo-active', [ClientCatalogueController::class, 'promoActive'])->name('promo.active');
     // Lookup tel international (Phase 5 etape 1).
     Route::get('/lookup', [ClientCatalogueController::class, 'lookup'])->middleware('throttle:5,1')->name('lookup');
     // Magic link + session client (Phase 5 etape 2).

--- a/frontend/src/features/admin/promotions/PromotionsPage.tsx
+++ b/frontend/src/features/admin/promotions/PromotionsPage.tsx
@@ -6,6 +6,7 @@ import {
   Eye,
   EyeOff,
   Gift,
+  Megaphone,
   Plus,
   RefreshCw,
   Search,
@@ -21,6 +22,7 @@ import {
   deleteRegleFidelite,
   getCodesPromo,
   getReglesFidelite,
+  setPromoPopup,
   updateCodePromo,
   updateRegleFidelite,
 } from './promotions.api'
@@ -56,6 +58,7 @@ const emptyCodeForm: CodePromoForm = {
   date_fin: '',
   limite_utilisation: '',
   actif: true,
+  afficher_popup: false,
 }
 
 const emptyRuleForm: RegleFideliteForm = {
@@ -129,6 +132,7 @@ function codeToForm(code: CodePromo): CodePromoForm {
     date_fin: toDateTimeInput(code.date_fin),
     limite_utilisation: code.limite_utilisation === null ? '' : String(code.limite_utilisation),
     actif: code.actif,
+    afficher_popup: code.afficher_popup,
   }
 }
 
@@ -486,6 +490,15 @@ function PromotionsPage() {
     }
   }
 
+  const togglePopup = async (code: CodePromo) => {
+    try {
+      await setPromoPopup(code.id, !code.afficher_popup)
+      await loadCodes(codePage, codeSearch, codeStatus)
+    } catch {
+      setError('Impossible de modifier le popup pour ce code.')
+    }
+  }
+
   const toggleRule = async (rule: RegleFidelite) => {
     try {
       await updateRegleFidelite(rule.id, { ...ruleToForm(rule), actif: !rule.actif })
@@ -703,6 +716,14 @@ function PromotionsPage() {
                     <div className="mt-4 flex justify-end gap-1">
                       <button
                         type="button"
+                        onClick={() => void togglePopup(code)}
+                        className={`flex h-9 w-9 items-center justify-center rounded-lg transition ${code.afficher_popup ? 'bg-[#e91e63] text-white hover:bg-[#c41468]' : 'text-gray-400 hover:bg-gray-100'}`}
+                        title={code.afficher_popup ? 'Desactiver le popup' : 'Afficher en popup'}
+                      >
+                        <Megaphone className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
                         onClick={() => void toggleCode(code)}
                         className="flex h-9 w-9 items-center justify-center rounded-lg text-gray-600 transition hover:bg-gray-100"
                         title={code.actif ? 'Desactiver' : 'Activer'}
@@ -790,6 +811,14 @@ function PromotionsPage() {
                           </td>
                           <td className="px-5 py-4">
                             <div className="flex justify-end gap-1">
+                              <button
+                                type="button"
+                                onClick={() => void togglePopup(code)}
+                                className={`flex h-9 w-9 items-center justify-center rounded-lg transition ${code.afficher_popup ? 'bg-[#e91e63] text-white hover:bg-[#c41468]' : 'text-gray-400 hover:bg-gray-100'}`}
+                                title={code.afficher_popup ? 'Desactiver le popup' : 'Afficher en popup'}
+                              >
+                                <Megaphone className="h-4 w-4" />
+                              </button>
                               <button
                                 type="button"
                                 onClick={() => void toggleCode(code)}
@@ -1076,6 +1105,16 @@ function PromotionsPage() {
                   onChange={(event) => setCodeForm((current) => ({ ...current, actif: event.target.checked }))}
                 />
                 Code actif
+              </label>
+              <label className="flex items-center gap-3 rounded-lg border border-[#fce4ec] bg-[#fff8fb] px-3 py-3 text-sm font-bold sm:col-span-2">
+                <input
+                  type="checkbox"
+                  checked={codeForm.afficher_popup}
+                  onChange={(event) => setCodeForm((current) => ({ ...current, afficher_popup: event.target.checked }))}
+                />
+                <Megaphone className="h-4 w-4 text-[#e91e63]" />
+                Afficher en popup sur le site client
+                <span className="ml-auto text-xs font-semibold text-gray-400">(remplace le popup actif)</span>
               </label>
             </div>
             <div className="flex flex-col-reverse gap-3 border-t border-gray-100 pt-5 sm:flex-row sm:justify-end">

--- a/frontend/src/features/admin/promotions/promotions.api.ts
+++ b/frontend/src/features/admin/promotions/promotions.api.ts
@@ -48,6 +48,7 @@ function codePromoPayload(form: CodePromoForm) {
     date_fin: cleanDateTime(form.date_fin),
     limite_utilisation: cleanNumber(form.limite_utilisation),
     actif: form.actif,
+    afficher_popup: form.afficher_popup,
   }
 }
 
@@ -83,6 +84,12 @@ export async function updateCodePromo(id: number, form: CodePromoForm) {
 
 export async function deleteCodePromo(id: number) {
   await apiClient.delete(`/admin/codes-promo/${id}`)
+}
+
+export async function setPromoPopup(id: number, afficher_popup: boolean) {
+  const response = await apiClient.patch<ApiItem<CodePromo>>(`/admin/codes-promo/${id}`, { afficher_popup })
+
+  return response.data.data
 }
 
 export async function getReglesFidelite(params?: QueryParams) {

--- a/frontend/src/features/admin/promotions/promotions.types.ts
+++ b/frontend/src/features/admin/promotions/promotions.types.ts
@@ -40,6 +40,7 @@ export type CodePromo = {
   limite_utilisation: number | null
   nombre_utilisations: number
   actif: boolean
+  afficher_popup: boolean
   created_at?: string
   updated_at?: string
 }
@@ -64,6 +65,7 @@ export type CodePromoForm = {
   date_fin: string
   limite_utilisation: string
   actif: boolean
+  afficher_popup: boolean
 }
 
 export type RegleFideliteForm = {

--- a/frontend/src/features/client/ClientHomePage.tsx
+++ b/frontend/src/features/client/ClientHomePage.tsx
@@ -54,6 +54,7 @@ import {
   todayInput,
 } from './client.helpers'
 import { CoiffureCard } from './components/CoiffureCard'
+import PromoPopup from './PromoPopup'
 import { usePhoneLookup } from './hooks/usePhoneLookup'
 import type {
   ClientAvailability,
@@ -749,6 +750,8 @@ function ClientHomePage() {
 
   return (
     <div className="min-h-screen bg-[#fdfafd] text-slate-950">
+
+      <PromoPopup />
 
       {/* Spinner pendant la vérification du paiement côté backend */}
       {paymentConfirming && (

--- a/frontend/src/features/client/PromoPopup.tsx
+++ b/frontend/src/features/client/PromoPopup.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+import { apiClient } from '../../lib/apiClient'
+
+type PromoData = {
+  id: number
+  code: string
+  nom: string | null
+  type_reduction: 'pourcentage' | 'montant'
+  valeur: number | string
+}
+
+const STORAGE_KEY = 'promo_popup_seen'
+
+function formatDiscount(type: 'pourcentage' | 'montant', valeur: number | string) {
+  const val = Number(valeur)
+
+  if (type === 'pourcentage') {
+    return `${val}% de réduction sur toutes les prestations`
+  }
+
+  return `${val.toLocaleString('fr-FR')} FCFA de réduction sur votre prochaine réservation`
+}
+
+function PromoPopup() {
+  const [promo, setPromo] = useState<PromoData | null>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (sessionStorage.getItem(STORAGE_KEY)) return
+
+    apiClient
+      .get<{ data: PromoData | null }>('/client/promo-active')
+      .then(({ data }) => {
+        if (data.data) {
+          setPromo(data.data)
+          setVisible(true)
+        }
+      })
+      .catch(() => {})
+  }, [])
+
+  const dismiss = () => {
+    sessionStorage.setItem(STORAGE_KEY, '1')
+    setVisible(false)
+  }
+
+  if (!visible || !promo) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Offre promotionnelle"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) dismiss()
+      }}
+    >
+      <div className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-white shadow-2xl">
+        <button
+          type="button"
+          onClick={dismiss}
+          className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/25 text-white transition hover:bg-black/45"
+          aria-label="Fermer"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        {/* En-tête gradient avec identité du salon */}
+        <div className="flex h-44 flex-col items-center justify-center bg-gradient-to-br from-[#e91e63] to-[#880e4f]">
+          <div className="mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-white/20 text-4xl">
+            ✂️
+          </div>
+          <p className="text-sm font-black uppercase tracking-widest text-white/90">Salon Thomas</p>
+          <p className="mt-1 text-xs font-semibold uppercase tracking-wider text-white/60">Dakar</p>
+        </div>
+
+        {/* Corps du popup */}
+        <div className="px-6 py-5 text-center">
+          <p className="text-xs font-black uppercase tracking-widest text-[#e91e63]">Offre Spéciale</p>
+
+          {promo.nom && (
+            <p className="mt-1 text-xl font-black text-gray-900">{promo.nom}</p>
+          )}
+
+          <p className="mt-2 text-sm font-semibold text-gray-500">
+            {formatDiscount(promo.type_reduction, promo.valeur)}
+          </p>
+
+          {/* Badge code promo avec copie au clic */}
+          <button
+            type="button"
+            onClick={() => {
+              void navigator.clipboard.writeText(promo.code)
+            }}
+            className="mt-3 inline-flex cursor-pointer items-center gap-2 rounded-lg bg-gray-50 px-4 py-2 transition hover:bg-gray-100"
+            title="Copier le code"
+          >
+            <span className="text-xs font-bold text-gray-500">Code :</span>
+            <span className="font-black tracking-widest text-[#e91e63]">{promo.code}</span>
+          </button>
+
+          {/* CTA principal */}
+          <a
+            href="/#catalogue"
+            onClick={dismiss}
+            className="mt-5 flex w-full items-center justify-center rounded-xl bg-gray-900 px-6 py-3 text-sm font-black text-white transition hover:bg-gray-700"
+          >
+            DÉCOUVRIR
+          </a>
+
+          {/* Lien de refus */}
+          <button
+            type="button"
+            onClick={dismiss}
+            className="mt-3 text-xs font-semibold text-gray-400 underline underline-offset-2 transition hover:text-gray-600"
+          >
+            Je ne suis pas intéressé(e)
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PromoPopup


### PR DESCRIPTION
- Migration : colonne afficher_popup (boolean) sur codes_promo avec index
- CodePromo : champ ajouté au fillable + cast boolean
- CodePromoController : validation afficher_popup + logique un seul popup actif à la fois
- CatalogueController : endpoint GET /client/promo-active (vérifie validité dates/limites)
- Route publique GET /api/client/promo-active ajoutée
- promotions.types.ts : afficher_popup dans CodePromo et CodePromoForm
- promotions.api.ts : payload inclut afficher_popup + fonction setPromoPopup()
- PromotionsPage.tsx : bouton Megaphone par ligne + case à cocher dans le formulaire
- PromoPopup.tsx : composant client (overlay, gradient, code copiable, sessionStorage)
- ClientHomePage.tsx : intègre <PromoPopup />