### PR TITLE
feat(seo): indexation Google — robots.txt, sitemap dynamique, JSON-LD…

### DIFF
--- a/backend/app/Http/Controllers/SitemapController.php
+++ b/backend/app/Http/Controllers/SitemapController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CategorieCoiffure;
+use Illuminate\Http\Response;
+
+class SitemapController extends Controller
+{
+    public function index(): Response
+    {
+        $categories = CategorieCoiffure::query()
+            ->where('actif', true)
+            ->orderBy('id')
+            ->get(['id', 'updated_at']);
+
+        $baseUrl = rtrim(config('app.frontend_url', 'https://bichettethomas.site'), '/');
+
+        $urls = [];
+
+        $urls[] = [
+            'loc' => $baseUrl . '/',
+            'changefreq' => 'weekly',
+            'priority' => '1.0',
+            'lastmod' => now()->toDateString(),
+        ];
+
+        $urls[] = [
+            'loc' => $baseUrl . '/categories',
+            'changefreq' => 'weekly',
+            'priority' => '0.8',
+            'lastmod' => $categories->max('updated_at')?->toDateString() ?? now()->toDateString(),
+        ];
+
+        foreach ($categories as $category) {
+            $urls[] = [
+                'loc' => $baseUrl . '/categories/' . $category->id,
+                'changefreq' => 'weekly',
+                'priority' => '0.7',
+                'lastmod' => $category->updated_at?->toDateString() ?? now()->toDateString(),
+            ];
+        }
+
+        $xml = $this->buildXml($urls);
+
+        return response($xml, 200, [
+            'Content-Type' => 'application/xml; charset=utf-8',
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+
+    /**
+     * @param array<int, array<string, string>> $urls
+     */
+    private function buildXml(array $urls): string
+    {
+        $items = '';
+        foreach ($urls as $url) {
+            $items .= sprintf(
+                "\n    <url>\n        <loc>%s</loc>\n        <lastmod>%s</lastmod>\n        <changefreq>%s</changefreq>\n        <priority>%s</priority>\n    </url>",
+                htmlspecialchars($url['loc'], ENT_XML1),
+                $url['lastmod'],
+                $url['changefreq'],
+                $url['priority'],
+            );
+        }
+
+        return '<?xml version="1.0" encoding="UTF-8"?>' . "\n"
+            . '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            . $items . "\n"
+            . '</urlset>';
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -35,10 +35,12 @@ use App\Http\Controllers\Api\Client\ReservationAvailabilityController as ClientR
 use App\Http\Controllers\Api\Client\ReservationController as ClientReservationController;
 use App\Http\Controllers\Api\DocumentationController;
 use App\Http\Controllers\Api\SeoController;
+use App\Http\Controllers\SitemapController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/documentation', [DocumentationController::class, 'ui']);
 Route::get('/openapi.json', [DocumentationController::class, 'openApi']);
+Route::get('/sitemap.xml', [SitemapController::class, 'index']);
 Route::get('/seo/{slug?}', [SeoController::class, 'show'])->where('slug', '.*');
 Route::post('/analytics/events', [AnalyticsController::class, 'store'])->middleware('throttle:30,1');
 Route::get('/reservations/disponibilites', ClientReservationAvailabilityController::class);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,18 +34,48 @@
     <meta property="og:title" content="Bichete Thomas — Salon de coiffure à Dakar" />
     <meta property="og:description" content="Réservez votre coiffure en ligne : tresses, locks, coiffures de cérémonie. Paiement Wave, Orange Money ou carte." />
     <meta property="og:locale" content="fr_FR" />
-    <!-- A remplacer par l URL canonique en prod (ex: https://bichete-thomas.sn). -->
-    <meta property="og:url" content="/" />
-    <!-- A remplacer par une image 1200x630 dediee aux partages sociaux. -->
-    <meta property="og:image" content="/logo-bichette.jpg" />
+    <meta property="og:url" content="https://bichettethomas.site/" />
+    <meta property="og:image" content="https://bichettethomas.site/logo-bichette.jpg" />
 
     <!-- Twitter Card : affichage carte au lieu de simple lien sur X/Twitter. -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Bichete Thomas — Salon de coiffure à Dakar" />
     <meta name="twitter:description" content="Réservez votre coiffure en ligne : tresses, locks, coiffures de cérémonie." />
-    <meta name="twitter:image" content="/logo-bichette.jpg" />
+    <meta name="twitter:image" content="https://bichettethomas.site/logo-bichette.jpg" />
 
+    <link rel="canonical" href="https://bichettethomas.site/" />
     <link rel="icon" type="image/jpeg" href="/logo-bichette.jpg" />
+
+    <!-- Schema.org LocalBusiness : permet à Google d afficher des infos riches
+         (adresse, horaires, téléphone) directement dans les résultats de recherche. -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "HairSalon",
+      "name": "Bichete Thomas",
+      "url": "https://bichettethomas.site",
+      "logo": "https://bichettethomas.site/logo-bichette.jpg",
+      "image": "https://bichettethomas.site/logo-bichette.jpg",
+      "description": "Salon de coiffure à Dakar spécialisé en tresses, locks, coiffures de cérémonie et soins capillaires. Réservation en ligne avec paiement Wave, Orange Money ou carte.",
+      "priceRange": "XOF",
+      "currenciesAccepted": "XOF",
+      "paymentAccepted": "Wave, Orange Money, carte bancaire",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Dakar",
+        "addressCountry": "SN"
+      },
+      "openingHoursSpecification": [
+        {
+          "@type": "OpeningHoursSpecification",
+          "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+          "opens": "09:00",
+          "closes": "19:00"
+        }
+      ],
+      "hasMap": "https://maps.google.com/?q=Dakar+Senegal"
+    }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /admin/
+
+Sitemap: https://bichettethomas.site/sitemap.xml

--- a/frontend/src/features/client/ClientCategoryPage.tsx
+++ b/frontend/src/features/client/ClientCategoryPage.tsx
@@ -5,6 +5,7 @@ import 'react-phone-number-input/style.css'
 import { useNavigate, useParams } from 'react-router-dom'
 import { confirmNaboopayReturn, createClientReservation, getClientAvailability, getClientCatalogue, getClientCoiffureDetails } from './client.api'
 import { usePhoneLookup } from './hooks/usePhoneLookup'
+import { useSeoPage } from '../../hooks/useSeoPage'
 import { coiffureImage, formatCurrency, formatDuration, formatShortDate, isClosedDate, todayInput } from './client.helpers'
 import { CoiffureCard } from './components/CoiffureCard'
 import type { ClientAvailability, ClientCatalogue, ClientCoiffure, ClientPaymentMethod, ClientPaymentWithRelations } from './client.types'
@@ -13,6 +14,7 @@ const emptyFavorites: number[] = []
 
 function ClientCategoryPage() {
   const { categoryId } = useParams()
+  useSeoPage(categoryId ? `categorie-${categoryId}` : 'categories')
   const navigate = useNavigate()
   const parsedCategoryId = categoryId ? Number(categoryId) : null
   const [catalogue, setCatalogue] = useState<ClientCatalogue | null>(null)

--- a/frontend/src/features/client/ClientHomePage.tsx
+++ b/frontend/src/features/client/ClientHomePage.tsx
@@ -55,6 +55,7 @@ import {
 } from './client.helpers'
 import { CoiffureCard } from './components/CoiffureCard'
 import PromoPopup from './PromoPopup'
+import { useSeoPage } from '../../hooks/useSeoPage'
 import { usePhoneLookup } from './hooks/usePhoneLookup'
 import type {
   ClientAvailability,
@@ -196,6 +197,7 @@ function scrollToSection(sectionId: string) {
 }
 
 function ClientHomePage() {
+  useSeoPage('accueil')
   const [catalogue, setCatalogue] = useState<ClientCatalogue | null>(null)
   const [loading, setLoading] = useState(true)
   const [catalogueError, setCatalogueError] = useState<string | null>(null)

--- a/frontend/src/hooks/useSeoPage.ts
+++ b/frontend/src/hooks/useSeoPage.ts
@@ -1,0 +1,97 @@
+import { useEffect } from 'react'
+import { apiClient } from '../lib/apiClient'
+
+interface PageSeo {
+  slug: string
+  meta_title: string | null
+  meta_description: string | null
+  canonical_url: string | null
+  image_og: string | null
+  schema_json: Record<string, unknown> | null
+}
+
+function setMeta(name: string, content: string) {
+  let el = document.querySelector<HTMLMetaElement>(`meta[name="${name}"]`)
+  if (!el) {
+    el = document.createElement('meta')
+    el.setAttribute('name', name)
+    document.head.appendChild(el)
+  }
+  el.content = content
+}
+
+function setOg(property: string, content: string) {
+  let el = document.querySelector<HTMLMetaElement>(`meta[property="${property}"]`)
+  if (!el) {
+    el = document.createElement('meta')
+    el.setAttribute('property', property)
+    document.head.appendChild(el)
+  }
+  el.content = content
+}
+
+function setCanonical(url: string) {
+  let el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+  if (!el) {
+    el = document.createElement('link')
+    el.rel = 'canonical'
+    document.head.appendChild(el)
+  }
+  el.href = url
+}
+
+function injectJsonLd(id: string, schema: Record<string, unknown>) {
+  removeJsonLd(id)
+  const script = document.createElement('script')
+  script.type = 'application/ld+json'
+  script.id = id
+  script.textContent = JSON.stringify(schema)
+  document.head.appendChild(script)
+}
+
+function removeJsonLd(id: string) {
+  document.getElementById(id)?.remove()
+}
+
+/**
+ * Injecte les balises SEO dynamiques depuis l'API pour la page courante.
+ * Si la page n'existe pas en base, ne fait rien (dégradation silencieuse).
+ */
+export function useSeoPage(slug: string) {
+  useEffect(() => {
+    const originalTitle = document.title
+    const controller = new AbortController()
+
+    apiClient
+      .get<{ data: PageSeo }>(`/seo/${slug}`, { signal: controller.signal })
+      .then(({ data: { data: seo } }) => {
+        if (seo.meta_title) {
+          document.title = seo.meta_title
+          setOg('og:title', seo.meta_title)
+        }
+        if (seo.meta_description) {
+          setMeta('description', seo.meta_description)
+          setOg('og:description', seo.meta_description)
+        }
+        if (seo.canonical_url) {
+          setCanonical(seo.canonical_url)
+          setOg('og:url', seo.canonical_url)
+        }
+        if (seo.image_og) {
+          setOg('og:image', seo.image_og)
+        }
+        if (seo.schema_json) {
+          injectJsonLd(`ld-json-${slug}`, seo.schema_json)
+        }
+      })
+      .catch(() => {
+        // Page SEO absente en base : on garde les balises statiques de index.html
+      })
+
+    return () => {
+      controller.abort()
+      document.title = originalTitle
+      removeJsonLd(`ld-json-${slug}`)
+    }
+  }, [slug])
+}

--- a/infra/docker/nginx/prod.conf
+++ b/infra/docker/nginx/prod.conf
@@ -85,6 +85,20 @@ server {
         access_log off;
     }
 
+    # ── Sitemap dynamique ─────────────────────────────────────────────────────
+    # Exact match (=) : intercepte /sitemap.xml avant le fallback SPA ci-dessous.
+    # REQUEST_URI est réécrit en /api/sitemap.xml pour correspondre aux routes Laravel.
+    location = /sitemap.xml {
+        include fastcgi_params;
+        fastcgi_pass           backend:9000;
+        fastcgi_param SCRIPT_FILENAME /var/www/html/public/index.php;
+        fastcgi_param SCRIPT_NAME     /index.php;
+        fastcgi_param DOCUMENT_ROOT   /var/www/html/public;
+        fastcgi_param HTTPS           on;
+        fastcgi_param REQUEST_URI     /api/sitemap.xml;
+        add_header Cache-Control "public, max-age=3600" always;
+    }
+
     # ── SPA React (fallback) ──────────────────────────────────────────────────
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
…, hook useSeoPage

- robots.txt bloquant /admin, référençant sitemap
- SitemapController : XML dynamique avec home + /categories + une URL par catégorie active
- Route GET /api/sitemap.xml + proxy nginx location = /sitemap.xml avant fallback SPA
- JSON-LD HairSalon (LocalBusiness) dans index.html avec adresse, horaires, paiements
- og:url, og:image et canonical mis à jour avec le domaine réel bichettethomas.site
- Hook useSeoPage : injecte title/meta/JSON-LD depuis l'API, nettoyage au unmount
- ClientHomePage : useSeoPage('accueil')
- ClientCategoryPage : useSeoPage('categorie-{id}') dynamique