### PR TITLE
perf(catalogue): invalidation cache immediate via CatalogueObserver

### DIFF
--- a/backend/app/Http/Controllers/Api/Client/CatalogueController.php
+++ b/backend/app/Http/Controllers/Api/Client/CatalogueController.php
@@ -33,7 +33,7 @@ class CatalogueController extends Controller
 
         $cacheKey = 'catalogue:v1:' . ($categoryId ? "cat-{$categoryId}" : 'all');
 
-        $data = Cache::remember($cacheKey, 300, fn () => $this->buildCatalogueData($categoryId, $search, $naboopayEnabled));
+        $data = Cache::tags(['catalogue'])->remember($cacheKey, 300, fn () => $this->buildCatalogueData($categoryId, $search, $naboopayEnabled));
 
         return response()->json(['data' => $data]);
     }

--- a/backend/app/Observers/CatalogueObserver.php
+++ b/backend/app/Observers/CatalogueObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Observers;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Invalide immédiatement le cache catalogue Redis dès qu'une coiffure,
+ * une catégorie ou un code promo est créé, modifié ou supprimé par l'admin.
+ * Enregistré sur Coiffure, CategorieCoiffure et CodePromo dans AppServiceProvider.
+ */
+class CatalogueObserver
+{
+    public function saved(mixed $model): void
+    {
+        Cache::tags(['catalogue'])->flush();
+    }
+
+    public function deleted(mixed $model): void
+    {
+        Cache::tags(['catalogue'])->flush();
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Models\CategorieCoiffure;
+use App\Models\CodePromo;
+use App\Models\Coiffure;
+use App\Observers\CatalogueObserver;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -28,5 +32,11 @@ class AppServiceProvider extends ServiceProvider
         if ($this->app->environment('production')) {
             URL::forceScheme('https');
         }
+
+        // Invalidation cache catalogue dès qu'un admin modifie une coiffure,
+        // une catégorie ou un code promo. Le flush est immédiat (pas d'attente TTL).
+        Coiffure::observe(CatalogueObserver::class);
+        CategorieCoiffure::observe(CatalogueObserver::class);
+        CodePromo::observe(CatalogueObserver::class);
     }
 }


### PR DESCRIPTION
- CatalogueObserver : flush Cache::tags(['catalogue']) sur saved/deleted
- Observateur enregistre sur Coiffure, CategorieCoiffure, CodePromo dans AppServiceProvider — toute modification admin invalide le cache immediatement sans attendre le TTL de 5 min
- CatalogueController : Cache::tags(['catalogue'])->remember() pour que le flush de l'observer cible exactement les bonnes cles