### PR TITLE
fix(catalogue): convertir toutes les Collections imbriquees en tablea…

### DIFF
--- a/backend/app/Http/Controllers/Api/Client/CatalogueController.php
+++ b/backend/app/Http/Controllers/Api/Client/CatalogueController.php
@@ -206,7 +206,7 @@ class CatalogueController extends Controller
             ] : null,
             'prix_min' => $minPrice,
             'duree_min_minutes' => $minDuration,
-            'images' => $images,
+            'images' => $images->all(),
             'avis_resume' => [
                 'moyenne' => $reviewsTotal > 0 ? round($reviewsAverage, 1) : 0,
                 'total' => $reviewsTotal,
@@ -219,12 +219,12 @@ class CatalogueController extends Controller
                 'nom' => $variant->nom,
                 'prix' => (float) $variant->prix,
                 'duree_minutes' => $variant->duree_minutes,
-            ])->values(),
+            ])->values()->all(),
             'options' => $coiffure->options->map(fn ($option): array => [
                 'id' => $option->id,
                 'nom' => $option->nom,
                 'prix' => (float) $option->prix,
-            ])->values(),
+            ])->values()->all(),
         ];
     }
 


### PR DESCRIPTION
…ux natifs

images, variantes et options dans formatCoiffure() etaient encore des Illuminate\Support\Collection stockees comme objets PHP serialises dans Redis — causes de __PHP_Incomplete_Class au deuxieme chargement.

- images : ->values() -> ->values()->all() (->all() suffit car deja values)
- variantes : ->values() -> ->values()->all()
- options : ->values() -> ->values()->all()

Desormais toute la donnee mise en cache est composee uniquement de tableaux PHP natifs et de scalaires, sans aucune reference de classe.