### PR TITLE
fix(k6): exclure 404/422/429 auth de http_req_failed via responseCallback

### DIFF
--- a/infra/scripts/k6-load-test.js
+++ b/infra/scripts/k6-load-test.js
@@ -182,6 +182,10 @@ export function connexion() {
     {
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
       tags:    { scenario: 'connexion' },
+      // 404 (numéro inconnu), 422 (validation), 429 (rate limit) sont des
+      // réponses attendues avec de faux numéros — ne pas les compter comme
+      // http_req_failed pour ne pas fausser le taux d'erreur global.
+      responseCallback: http.expectedStatuses({ min: 200, max: 299 }, 404, 422, 429),
     }
   )
   authDuration.add(Date.now() - debut)


### PR DESCRIPTION
Les faux numeros de telephone du scenario connexion retournent 404 (numero inconnu), ce qui est le comportement attendu. Mais k6 comptait ces reponses dans http_req_failed et faussait le taux d'erreur global (5.72% observe alors que l'application fonctionnait correctement).

responseCallback: http.expectedStatuses(...) indique a k6 que ces codes sont des reponses valides pour cet endpoint specifique.