### PR TITLE
feat(gerante): panel réservations avec transitions restreintes et logs enrichis

### DIFF
--- a/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Http\Controllers\Api\Gerante;
+
+use App\Http\Controllers\Controller;
+use App\Models\Reservation;
+use App\Services\SystemLogger;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class ReservationController extends Controller
+{
+    // Transitions autorisees pour la gerante. Plus restrictives que l admin :
+    // elle gere le quotidien (accueil, passage en cours, cloture) mais ne
+    // peut pas modifier les paiements ni acceder a la caisse.
+    private const TRANSITIONS = [
+        'en_attente'   => ['confirmee', 'annulee', 'absence'],
+        'confirmee'    => ['en_cours', 'annulee', 'absence'],
+        'acompte_paye' => ['en_cours', 'terminee', 'annulee', 'absence'],
+        'en_cours'     => ['terminee', 'annulee', 'absence'],
+        'terminee'     => [],
+        'annulee'      => [],
+        'absence'      => [],
+    ];
+
+    // Transitions sensibles : un acompte a deja ete encaisse. La raison est
+    // obligatoire (min 20 car.) pour tracer toute annulation post-paiement
+    // et decourager les detournements de caisse.
+    private const SENSITIVE_TRANSITIONS = [
+        'acompte_paye' => ['annulee', 'absence'],
+    ];
+
+    public function __construct(private readonly SystemLogger $logger) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = max(1, min($request->integer('per_page', 20), 100));
+
+        $reservations = Reservation::query()
+            ->with($this->relations())
+            ->when($request->filled('statut'), fn ($q) => $q->where('statut', $request->string('statut')->toString()))
+            ->when($request->filled('date'), fn ($q) => $q->whereDate('date_reservation', $request->date('date')))
+            ->when($request->filled('date_from'), fn ($q) => $q->whereDate('date_reservation', '>=', $request->date('date_from')))
+            ->when($request->filled('date_to'), fn ($q) => $q->whereDate('date_reservation', '<=', $request->date('date_to')))
+            ->when($request->filled('search'), function ($q) use ($request): void {
+                $search = trim($request->string('search')->toString());
+                $q->whereHas('client', function ($cq) use ($search): void {
+                    $cq->where('nom', 'ilike', "%{$search}%")
+                        ->orWhere('prenom', 'ilike', "%{$search}%")
+                        ->orWhere('telephone', 'ilike', "%{$search}%");
+                });
+                if (ctype_digit($search)) {
+                    $q->orWhere('id', (int) $search);
+                }
+            })
+            ->orderByDesc('date_reservation')
+            ->orderBy('heure_debut')
+            ->paginate($perPage);
+
+        return response()->json(['data' => $reservations]);
+    }
+
+    public function show(Reservation $reservation): JsonResponse
+    {
+        return response()->json([
+            'data' => $reservation->load($this->relations()),
+        ]);
+    }
+
+    public function updateStatus(Request $request, Reservation $reservation): JsonResponse
+    {
+        $isSensitive = in_array(
+            $request->input('statut'),
+            self::SENSITIVE_TRANSITIONS[$reservation->statut] ?? [],
+            true
+        );
+
+        $data = $request->validate([
+            'statut' => ['required', Rule::in(array_keys(self::TRANSITIONS))],
+            // Raison obligatoire uniquement pour les transitions post-acompte
+            'raison'  => $isSensitive
+                ? ['required', 'string', 'min:20', 'max:1000']
+                : ['sometimes', 'nullable', 'string', 'max:1000'],
+        ]);
+
+        $allowed = self::TRANSITIONS[$reservation->statut] ?? [];
+
+        if (! in_array($data['statut'], $allowed, true)) {
+            throw ValidationException::withMessages([
+                'statut' => "Transition non autorisee pour la gerante : {$reservation->statut} → {$data['statut']}.",
+            ]);
+        }
+
+        $oldStatus = $reservation->statut;
+        $newStatus = $data['statut'];
+
+        $reservation->statut = $newStatus;
+        $this->applyStatusTimestamps($reservation);
+        $reservation->save();
+
+        $this->logStatusChange($request, $reservation, $oldStatus, $newStatus, $data['raison'] ?? null, $isSensitive);
+
+        return response()->json([
+            'message' => 'Statut mis a jour.',
+            'data'    => $reservation->load($this->relations()),
+        ]);
+    }
+
+    private function logStatusChange(
+        Request     $request,
+        Reservation $reservation,
+        string      $oldStatus,
+        string      $newStatus,
+        ?string     $raison,
+        bool        $isSensitive,
+    ): void {
+        // Les transitions sensibles (post-acompte) sont tracees avec une
+        // action distincte pour que l admin puisse les filtrer dans les logs.
+        $action = $isSensitive ? 'alerte_gerante_annulation_depot' : 'gerante_changement_statut';
+
+        $this->logger->record(
+            action: $action,
+            module: 'reservations',
+            description: "Reservation #{$reservation->id} : {$oldStatus} → {$newStatus}",
+            subject: $reservation,
+            before: ['statut' => $oldStatus],
+            after:  ['statut' => $newStatus],
+            metadata: array_filter([
+                'reservation_id'    => $reservation->id,
+                'client_id'         => $reservation->client_id,
+                'montant_acompte'   => $reservation->montant_acompte,
+                'raison'            => $raison,
+                'actor_role'        => 'gerante',
+            ]),
+            request: $request,
+        );
+    }
+
+    private function applyStatusTimestamps(Reservation $reservation): void
+    {
+        if ($reservation->statut === 'terminee' && ! $reservation->terminee_at) {
+            $reservation->terminee_at = now();
+        }
+        if ($reservation->statut !== 'terminee') {
+            $reservation->terminee_at = null;
+        }
+        if ($reservation->statut === 'annulee' && ! $reservation->annulee_at) {
+            $reservation->annulee_at = now();
+        }
+        if ($reservation->statut !== 'annulee') {
+            $reservation->annulee_at = null;
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function relations(): array
+    {
+        return [
+            'client',
+            'coiffeuse',
+            'details.coiffure',
+            'details.variante',
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Api\Admin\DepenseController;
 use App\Http\Controllers\Api\Admin\EvenementAnalyticsController;
 use App\Http\Controllers\Api\Admin\GeranteController;
 use App\Http\Controllers\Api\Admin\ImageCoiffureController;
+use App\Http\Controllers\Api\Gerante\ReservationController as GeranteReservationController;
 use App\Http\Controllers\Api\Admin\ListeNoireClientController;
 use App\Http\Controllers\Api\Admin\LogSystemeController;
 use App\Http\Controllers\Api\Admin\MouvementCaisseController;
@@ -144,4 +145,16 @@ Route::middleware(['auth.token', 'role:admin', 'log.admin'])
         Route::apiResource('evenements-analytics', EvenementAnalyticsController::class)
             ->only(['index', 'show'])
             ->parameters(['evenements-analytics' => 'evenementAnalytics']);
+    });
+
+// Espace gérante : accès restreint au suivi des réservations du jour.
+// Séparé du groupe admin pour ne donner que les permissions nécessaires
+// (principe du moindre privilège) et faciliter l'évolution indépendante.
+Route::middleware(['auth.token', 'role:gerante', 'log.admin'])
+    ->prefix('gerante')
+    ->name('gerante.')
+    ->group(function (): void {
+        Route::get('reservations', [GeranteReservationController::class, 'index'])->name('reservations.index');
+        Route::get('reservations/{reservation}', [GeranteReservationController::class, 'show'])->name('reservations.show');
+        Route::patch('reservations/{reservation}/statut', [GeranteReservationController::class, 'updateStatus'])->name('reservations.statut');
     });


### PR DESCRIPTION
- Nouveau namespace Api\Gerante séparé de Api\Admin (moindre privilège)
- GET /api/gerante/reservations + show : lecture seule des réservations
- PATCH /api/gerante/reservations/{id}/statut : transitions restreintes · acompte_paye → annulee/absence exige raison min 20 car. · aucun accès caisse, paiements, catalogue, rapports
- Log SystemLogger avec before/after statut + raison + actor_role
- action='alerte_gerante_annulation_depot' pour filtrage admin rapide