### PR TITLE
test(regression): isolation roles, statuts gerante et statuts admin

### DIFF
--- a/backend/tests/Feature/Admin/ReservationStatusTest.php
+++ b/backend/tests/Feature/Admin/ReservationStatusTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Reservation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tests d integration sur PATCH /api/admin/reservations/{id}/statut.
+ *
+ * Couvre :
+ * - transitions valides avec et sans notes
+ * - transitions non autorisees refusees en 422
+ * - acces refuse sans token (401) et avec token gerante (403)
+ *
+ * Note : l admin ne cree pas de paiement lors du changement de statut
+ * (contrairement a la gerante). La creation de paiement passe par
+ * POST /api/admin/paiements.
+ */
+class ReservationStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── Acces ───────────────────────────────────────────────────────────────
+
+    public function test_sans_token_refuse_401(): void
+    {
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+            'statut' => 'confirmee',
+        ])->assertStatus(401);
+    }
+
+    public function test_token_gerante_refuse_403(): void
+    {
+        $auth        = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'confirmee',
+            ])
+            ->assertStatus(403);
+    }
+
+    // ─── Transitions valides ─────────────────────────────────────────────────
+
+    public function test_en_attente_vers_confirmee(): void
+    {
+        $auth        = $this->loggedInAdmin();
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'confirmee',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'confirmee');
+    }
+
+    public function test_confirmee_vers_en_cours(): void
+    {
+        $auth        = $this->loggedInAdmin();
+        $reservation = Reservation::factory()->create(['statut' => 'confirmee']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'en_cours',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'en_cours');
+    }
+
+    public function test_en_cours_vers_terminee(): void
+    {
+        $auth        = $this->loggedInAdmin();
+        $reservation = Reservation::factory()->create([
+            'statut'          => 'en_cours',
+            'montant_restant' => 0,
+        ]);
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'terminee',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.statut', 'terminee');
+
+        $this->assertNotNull(
+            Reservation::find($reservation->id)->terminee_at
+        );
+    }
+
+    public function test_statut_accepte_une_note(): void
+    {
+        $auth        = $this->loggedInAdmin();
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'annulee',
+                'notes'  => 'Annulation a la demande de la cliente.',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'annulee');
+    }
+
+    public function test_en_attente_vers_absence(): void
+    {
+        $auth        = $this->loggedInAdmin();
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'absence',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'absence');
+    }
+
+    // ─── Transitions non autorisees ──────────────────────────────────────────
+
+    public function test_terminee_vers_en_cours_refuse_422(): void
+    {
+        $auth        = $this->loggedInAdmin();
+        $reservation = Reservation::factory()->create(['statut' => 'terminee']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'en_cours',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['statut']);
+    }
+
+    public function test_annulee_vers_confirmee_refuse_422(): void
+    {
+        $auth        = $this->loggedInAdmin();
+        $reservation = Reservation::factory()->create(['statut' => 'annulee']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'confirmee',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['statut']);
+    }
+
+    public function test_statut_invalide_refuse_422(): void
+    {
+        $auth        = $this->loggedInAdmin();
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'inexistant',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['statut']);
+    }
+}

--- a/backend/tests/Feature/Admin/ReservationStatusTest.php
+++ b/backend/tests/Feature/Admin/ReservationStatusTest.php
@@ -48,32 +48,35 @@ class ReservationStatusTest extends TestCase
 
     // ─── Transitions valides ─────────────────────────────────────────────────
 
-    public function test_en_attente_vers_confirmee(): void
+    public function test_acompte_paye_vers_terminee(): void
     {
         $auth        = $this->loggedInAdmin();
-        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+        $reservation = Reservation::factory()->create([
+            'statut'          => 'acompte_paye',
+            'montant_restant' => 0,
+        ]);
 
         $this->authenticatedAs($auth)
             ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
             ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
-                'statut' => 'confirmee',
+                'statut' => 'terminee',
             ])
             ->assertOk()
-            ->assertJsonPath('data.statut', 'confirmee');
+            ->assertJsonPath('data.statut', 'terminee');
     }
 
-    public function test_confirmee_vers_en_cours(): void
+    public function test_en_cours_vers_annulee(): void
     {
         $auth        = $this->loggedInAdmin();
-        $reservation = Reservation::factory()->create(['statut' => 'confirmee']);
+        $reservation = Reservation::factory()->create(['statut' => 'en_cours']);
 
         $this->authenticatedAs($auth)
             ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
             ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
-                'statut' => 'en_cours',
+                'statut' => 'annulee',
             ])
             ->assertOk()
-            ->assertJsonPath('data.statut', 'en_cours');
+            ->assertJsonPath('data.statut', 'annulee');
     }
 
     public function test_en_cours_vers_terminee(): void

--- a/backend/tests/Feature/Gerante/ReservationStatusTest.php
+++ b/backend/tests/Feature/Gerante/ReservationStatusTest.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Tests\Feature\Gerante;
+
+use App\Models\LogSysteme;
+use App\Models\Paiement;
+use App\Models\Reservation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tests d integration sur PATCH /api/gerante/reservations/{id}/statut.
+ *
+ * Couvre :
+ * - transitions valides (confirmee, en_cours, terminee, annulee, absence)
+ * - terminee sans solde restant
+ * - terminee avec solde : paiement cree, numero_recu bien formate (BT-YYYYMMDD-XXXX)
+ * - terminee avec solde : option de ne pas enregistrer le paiement
+ * - transition sensible (acompte_paye -> annulee) : raison obligatoire + log alerte
+ * - transition sensible (acompte_paye -> absence) : meme exigence
+ * - raison trop courte (<20 caracteres) refuse en 422
+ * - transition non autorisee refuse en 422
+ * - acces sans token refuse en 401
+ */
+class ReservationStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── Acces ───────────────────────────────────────────────────────────────
+
+    public function test_sans_token_acces_refuse_401(): void
+    {
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+            'statut' => 'confirmee',
+        ])->assertStatus(401);
+    }
+
+    // ─── Transitions simples ─────────────────────────────────────────────────
+
+    public function test_en_attente_vers_confirmee(): void
+    {
+        $auth        = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'confirmee',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'confirmee');
+    }
+
+    public function test_confirmee_vers_en_cours(): void
+    {
+        $auth        = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'confirmee']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'en_cours',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'en_cours');
+    }
+
+    public function test_en_cours_vers_annulee(): void
+    {
+        $auth        = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'en_cours']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'annulee',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'annulee');
+    }
+
+    // ─── Terminee sans solde restant ─────────────────────────────────────────
+
+    public function test_en_cours_vers_terminee_sans_solde_restant(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create([
+            'statut'          => 'en_cours',
+            'montant_restant' => 0,
+        ]);
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'terminee',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.statut', 'terminee');
+
+        // terminee_at doit etre renseigne.
+        $this->assertNotNull(
+            Reservation::find($reservation->id)->terminee_at
+        );
+
+        // Aucun paiement cree.
+        $this->assertDatabaseCount('paiements', 0);
+    }
+
+    // ─── Terminee avec solde : paiement enregistre ───────────────────────────
+
+    public function test_en_cours_vers_terminee_avec_solde_enregistre(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create([
+            'statut'          => 'en_cours',
+            'montant_total'   => 20000,
+            'montant_restant' => 15000,
+            'devise'          => 'FCFA',
+        ]);
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut'               => 'terminee',
+                'enregistrer_paiement' => true,
+                'mode_paiement_solde'  => 'especes',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.statut', 'terminee');
+
+        // Un paiement de type solde doit etre cree.
+        $this->assertDatabaseCount('paiements', 1);
+        $paiement = Paiement::first();
+
+        $this->assertSame('solde', $paiement->type);
+        $this->assertSame('especes', $paiement->mode_paiement);
+        $this->assertSame('valide', $paiement->statut);
+        $this->assertEquals(15000, $paiement->montant);
+
+        // numero_recu doit respecter le format BT-YYYYMMDD-XXXX.
+        $this->assertMatchesRegularExpression(
+            '/^BT-\d{8}-\d{4}$/',
+            $paiement->numero_recu
+        );
+
+        // montant_restant remis a zero en base.
+        $this->assertEquals(0, Reservation::find($reservation->id)->montant_restant);
+    }
+
+    public function test_enregistrer_paiement_requis_quand_solde_positif(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create([
+            'statut'          => 'en_cours',
+            'montant_restant' => 15000,
+        ]);
+
+        // Champ enregistrer_paiement absent alors que montant_restant > 0.
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'terminee',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['enregistrer_paiement']);
+    }
+
+    public function test_mode_paiement_requis_si_enregistrer_paiement_true(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create([
+            'statut'          => 'en_cours',
+            'montant_restant' => 15000,
+        ]);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut'               => 'terminee',
+                'enregistrer_paiement' => true,
+                // mode_paiement_solde absent
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['mode_paiement_solde']);
+    }
+
+    public function test_en_cours_vers_terminee_avec_solde_non_enregistre(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create([
+            'statut'          => 'en_cours',
+            'montant_restant' => 15000,
+        ]);
+
+        // La gerante choisit de ne pas enregistrer le paiement maintenant.
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut'               => 'terminee',
+                'enregistrer_paiement' => false,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'terminee');
+
+        // Aucun paiement cree.
+        $this->assertDatabaseCount('paiements', 0);
+    }
+
+    // ─── Transitions sensibles (post-acompte) ────────────────────────────────
+
+    public function test_acompte_paye_vers_annulee_sans_raison_refuse_422(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'acompte_paye']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'annulee',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['raison']);
+    }
+
+    public function test_acompte_paye_vers_annulee_avec_raison_trop_courte_refuse_422(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'acompte_paye']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'annulee',
+                'raison' => 'Trop court',  // < 20 caracteres
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['raison']);
+    }
+
+    public function test_acompte_paye_vers_annulee_avec_raison_valide_cree_log_alerte(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create([
+            'statut'          => 'acompte_paye',
+            'montant_acompte' => 5000,
+        ]);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'annulee',
+                'raison' => 'Annulation demandee par la cliente pour raison personnelle.',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'annulee');
+
+        // Un log d alerte doit etre cree avec l action speciale.
+        $this->assertDatabaseHas('logs_systeme', [
+            'action' => 'alerte_gerante_annulation_depot',
+            'module' => 'reservations',
+        ]);
+    }
+
+    public function test_acompte_paye_vers_absence_sans_raison_refuse_422(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'acompte_paye']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'absence',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['raison']);
+    }
+
+    // ─── Transitions non autorisees ──────────────────────────────────────────
+
+    public function test_terminee_vers_en_cours_refuse_422(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'terminee']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'en_cours',
+            ])
+            ->assertStatus(422);
+    }
+
+    public function test_annulee_vers_confirmee_refuse_422(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'annulee']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'confirmee',
+            ])
+            ->assertStatus(422);
+    }
+
+    public function test_en_attente_vers_terminee_refuse_422(): void
+    {
+        $auth = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        // en_attente n a pas acces direct a terminee dans les transitions gerante.
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'terminee',
+            ])
+            ->assertStatus(422);
+    }
+
+    // ─── Log de base sur transition normale ──────────────────────────────────
+
+    public function test_changement_normal_cree_un_log_systeme(): void
+    {
+        $auth        = $this->loggedInGerante();
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'confirmee',
+            ])
+            ->assertOk();
+
+        $this->assertDatabaseHas('logs_systeme', [
+            'action' => 'gerante_changement_statut',
+            'module' => 'reservations',
+        ]);
+    }
+}

--- a/backend/tests/Feature/Security/RoleIsolationTest.php
+++ b/backend/tests/Feature/Security/RoleIsolationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Verifie que les middlewares role:admin et role:gerante sont en place
+ * et que personne ne peut acceder a un espace qui n est pas le sien.
+ *
+ * Ces tests sont le filet de securite le plus important : si quelqu un
+ * retire accidentellement un middleware de route, une gerante pourrait
+ * obtenir un acces admin complet sans que personne ne le remarque
+ * jusqu en production. Ce test l attrape immediatement.
+ */
+class RoleIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── Sans token ──────────────────────────────────────────────────────────
+
+    public function test_sans_token_acces_admin_refuse_401(): void
+    {
+        $this->getJson('/api/admin/reservations')->assertStatus(401);
+    }
+
+    public function test_sans_token_acces_gerante_refuse_401(): void
+    {
+        $this->getJson('/api/gerante/reservations')->assertStatus(401);
+    }
+
+    public function test_sans_token_acces_admin_clients_refuse_401(): void
+    {
+        $this->getJson('/api/admin/clients')->assertStatus(401);
+    }
+
+    public function test_sans_token_acces_dashboard_refuse_401(): void
+    {
+        $this->getJson('/api/admin/dashboard')->assertStatus(401);
+    }
+
+    // ─── Gerante ne peut pas acceder a l espace admin ────────────────────────
+
+    public function test_gerante_ne_peut_pas_acceder_aux_reservations_admin(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/admin/reservations')
+            ->assertStatus(403)
+            ->assertJsonPath('message', 'Acces non autorise pour ce role.');
+    }
+
+    public function test_gerante_ne_peut_pas_acceder_aux_clients_admin(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/admin/clients')
+            ->assertStatus(403);
+    }
+
+    public function test_gerante_ne_peut_pas_acceder_au_dashboard_admin(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/admin/dashboard')
+            ->assertStatus(403);
+    }
+
+    public function test_gerante_ne_peut_pas_acceder_aux_paiements_admin(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/admin/paiements')
+            ->assertStatus(403);
+    }
+
+    public function test_gerante_ne_peut_pas_acceder_aux_logs_admin(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/admin/logs-systeme')
+            ->assertStatus(403);
+    }
+
+    public function test_gerante_ne_peut_pas_acceder_a_la_caisse(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/admin/caisses/du-jour')
+            ->assertStatus(403);
+    }
+
+    // ─── Admin ne peut pas acceder a l espace gerante ────────────────────────
+
+    public function test_admin_ne_peut_pas_acceder_aux_reservations_gerante(): void
+    {
+        $auth = $this->loggedInAdmin();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/gerante/reservations')
+            ->assertStatus(403)
+            ->assertJsonPath('message', 'Acces non autorise pour ce role.');
+    }
+
+    public function test_admin_ne_peut_pas_changer_statut_via_route_gerante(): void
+    {
+        $auth = $this->loggedInAdmin();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson('/api/gerante/reservations/1/statut', ['statut' => 'confirmee'])
+            ->assertStatus(403);
+    }
+}

--- a/backend/tests/Feature/Security/RoleIsolationTest.php
+++ b/backend/tests/Feature/Security/RoleIsolationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Security;
 
+use App\Models\Reservation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -111,11 +112,14 @@ class RoleIsolationTest extends TestCase
 
     public function test_admin_ne_peut_pas_changer_statut_via_route_gerante(): void
     {
-        $auth = $this->loggedInAdmin();
+        $auth        = $this->loggedInAdmin();
+        // Une reservation doit exister pour que le route model binding ne
+        // retourne pas 404 avant que le middleware role:gerante ne s execute.
+        $reservation = Reservation::factory()->create(['statut' => 'en_attente']);
 
         $this->authenticatedAs($auth)
             ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
-            ->patchJson('/api/gerante/reservations/1/statut', ['statut' => 'confirmee'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", ['statut' => 'confirmee'])
             ->assertStatus(403);
     }
 }

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -109,4 +109,44 @@ abstract class TestCase extends BaseTestCase
         // (defaut "no credentials, no cookies").
         return $this->withCredentials()->withUnencryptedCookies($auth['cookies']);
     }
+
+    /**
+     * Cree un utilisateur gerante actif.
+     */
+    protected function createGeranteUser(string $email = 'gerante@test.local', string $password = 'TestAdmin2026!'): User
+    {
+        $role = Role::query()->firstOrCreate(
+            ['nom' => 'gerante'],
+            ['description' => 'Gerante (test)'],
+        );
+
+        return User::query()->create([
+            'role_id'            => $role->id,
+            'name'               => 'Test Gerante',
+            'email'              => $email,
+            'password'           => Hash::make($password),
+            'actif'              => true,
+            'email_verified_at'  => now(),
+        ]);
+    }
+
+    /**
+     * Login complet en tant que gerante — meme interface que loggedInAdmin().
+     *
+     * @return array{user: User, cookies: array<string, string>, csrf: string}
+     */
+    protected function loggedInGerante(string $email = 'gerante@test.local'): array
+    {
+        $user  = $this->createGeranteUser($email);
+        $login = $this->loginAs($user);
+        $login->assertOk();
+
+        $cookies = $this->extractAuthCookies($login);
+
+        return [
+            'user'    => $user,
+            'cookies' => $cookies,
+            'csrf'    => $cookies[AuthController::CSRF_COOKIE] ?? '',
+        ];
+    }
 }


### PR DESCRIPTION
- TestCase : helpers createGeranteUser() + loggedInGerante()
- RoleIsolationTest : 10 tests verifiant que gerante != admin (acces sans token -> 401, gerante sur routes admin -> 403, admin sur routes gerante -> 403)
- GeranteReservationStatusTest : 14 tests couvrant toutes les transitions, solde avec/sans paiement, numero_recu BT-YYYYMMDD-XXXX, raison obligatoire sur transitions sensibles, log alerte cree
- AdminReservationStatusTest : 9 tests couvrant transitions valides, notes, acces role, transitions interdites