### PR TITLE
feat(gerante): gestion des clientes physiques (CRUD + logs)

### DIFF
--- a/backend/app/Http/Controllers/Api/Gerante/ClientController.php
+++ b/backend/app/Http/Controllers/Api/Gerante/ClientController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers\Api\Gerante;
+
+use App\Http\Controllers\Controller;
+use App\Models\Client;
+use App\Services\SystemLogger;
+use App\Support\PhoneNumber;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Propaganistas\LaravelPhone\Rules\Phone;
+
+class ClientController extends Controller
+{
+    public function __construct(private readonly SystemLogger $logger) {}
+
+    /**
+     * Pre-normalise le tel en E.164 AVANT la regle "unique" — meme logique
+     * que le ClientController admin pour eviter les faux doublons de format.
+     */
+    private function normalizePhoneInput(Request $request): void
+    {
+        $raw = $request->input('telephone');
+
+        if (! is_string($raw)) {
+            return;
+        }
+
+        $normalized = PhoneNumber::normalize($raw);
+
+        if ($normalized !== null) {
+            $request->merge(['telephone' => $normalized]);
+        }
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = max(1, min($request->integer('per_page', 15), 100));
+
+        $clients = Client::query()
+            ->with(['preferences', 'blacklistActive'])
+            ->when($request->filled('search'), function ($query) use ($request): void {
+                $search = trim($request->string('search')->toString());
+
+                $query->where(function ($query) use ($search): void {
+                    $query->where('nom', 'ilike', "%{$search}%")
+                        ->orWhere('prenom', 'ilike', "%{$search}%")
+                        ->orWhere('telephone', 'ilike', "%{$search}%")
+                        ->orWhere('email', 'ilike', "%{$search}%");
+                });
+            })
+            ->latest()
+            ->paginate($perPage);
+
+        return response()->json(['data' => $clients]);
+    }
+
+    public function show(Client $client): JsonResponse
+    {
+        return response()->json([
+            'data' => $client->load(['preferences', 'blacklistActive']),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $this->normalizePhoneInput($request);
+
+        $data = $request->validate([
+            'nom'       => ['required', 'string', 'max:255'],
+            'prenom'    => ['required', 'string', 'max:255'],
+            'telephone' => ['required', 'string', 'max:30', (new Phone())->country(['SN'])->international(), 'unique:clients,telephone'],
+            'email'     => ['nullable', 'email', 'max:255'],
+        ]);
+
+        // La gerante cree uniquement des clientes physiques (comptoir).
+        $data['source'] = 'physique';
+
+        $client = Client::query()->create($data);
+        $client->preferences()->create([
+            'notifications_whatsapp' => true,
+            'notifications_promos'   => true,
+        ]);
+
+        $this->logger->record(
+            action: 'gerante_creation_client',
+            module: 'clients',
+            description: "Nouvelle cliente physique : {$client->prenom} {$client->nom}",
+            subject: $client,
+            after: ['nom' => $client->nom, 'prenom' => $client->prenom, 'telephone' => $client->telephone, 'email' => $client->email],
+            metadata: ['actor_role' => 'gerante'],
+            request: $request,
+        );
+
+        return response()->json([
+            'message' => 'Cliente creee.',
+            'data'    => $client->load(['preferences', 'blacklistActive']),
+        ], 201);
+    }
+
+    public function update(Request $request, Client $client): JsonResponse
+    {
+        $this->normalizePhoneInput($request);
+
+        $data = $request->validate([
+            'nom'       => ['sometimes', 'string', 'max:255'],
+            'prenom'    => ['sometimes', 'string', 'max:255'],
+            'telephone' => ['sometimes', 'string', 'max:30', (new Phone())->country(['SN'])->international(), Rule::unique('clients', 'telephone')->ignore($client->id)],
+            'email'     => ['nullable', 'email', 'max:255'],
+        ]);
+
+        $before = [
+            'nom'       => $client->nom,
+            'prenom'    => $client->prenom,
+            'telephone' => $client->telephone,
+            'email'     => $client->email,
+        ];
+
+        $client->update($data);
+
+        $this->logger->record(
+            action: 'gerante_modification_client',
+            module: 'clients',
+            description: "Modification coordonnees : {$client->prenom} {$client->nom}",
+            subject: $client,
+            before: $before,
+            after: ['nom' => $client->nom, 'prenom' => $client->prenom, 'telephone' => $client->telephone, 'email' => $client->email],
+            metadata: ['actor_role' => 'gerante'],
+            request: $request,
+        );
+
+        return response()->json([
+            'message' => 'Cliente mise a jour.',
+            'data'    => $client->load(['preferences', 'blacklistActive']),
+        ]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Api\Admin\DepenseController;
 use App\Http\Controllers\Api\Admin\EvenementAnalyticsController;
 use App\Http\Controllers\Api\Admin\GeranteController;
 use App\Http\Controllers\Api\Admin\ImageCoiffureController;
+use App\Http\Controllers\Api\Gerante\ClientController as GeranteClientController;
 use App\Http\Controllers\Api\Gerante\ReservationController as GeranteReservationController;
 use App\Http\Controllers\Api\Admin\ListeNoireClientController;
 use App\Http\Controllers\Api\Admin\LogSystemeController;
@@ -161,4 +162,8 @@ Route::middleware(['auth.token', 'role:gerante', 'log.admin'])
         Route::get('reservations', [GeranteReservationController::class, 'index'])->name('reservations.index');
         Route::get('reservations/{reservation}', [GeranteReservationController::class, 'show'])->name('reservations.show');
         Route::patch('reservations/{reservation}/statut', [GeranteReservationController::class, 'updateStatus'])->name('reservations.statut');
+        Route::get('clients', [GeranteClientController::class, 'index'])->name('clients.index');
+        Route::post('clients', [GeranteClientController::class, 'store'])->name('clients.store');
+        Route::get('clients/{client}', [GeranteClientController::class, 'show'])->name('clients.show');
+        Route::put('clients/{client}', [GeranteClientController::class, 'update'])->name('clients.update');
     });

--- a/backend/tests/Feature/Gerante/ClientTest.php
+++ b/backend/tests/Feature/Gerante/ClientTest.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace Tests\Feature\Gerante;
+
+use App\Models\Client;
+use App\Models\LogSysteme;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tests d integration sur les routes GET/POST/PUT /api/gerante/clients.
+ *
+ * Couvre :
+ * - acces sans token refuse en 401
+ * - acces admin refuse en 403
+ * - liste paginee et recherche
+ * - creation d une cliente physique (source forcee)
+ * - creation refuse si telephone invalide ou duplique
+ * - modification des coordonnees autorisee
+ * - modification refuse si telephone duplique
+ * - champs interdits ignores a la creation (source, nombre_reservations_terminees, fidelite_disponible)
+ * - champs interdits ignores a la modification (source, nombre_reservations_terminees, fidelite_disponible)
+ * - log cree a la creation
+ * - log cree a la modification avec before/after
+ */
+class ClientTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── Acces ───────────────────────────────────────────────────────────────
+
+    public function test_sans_token_liste_refuse_401(): void
+    {
+        $this->getJson('/api/gerante/clients')->assertStatus(401);
+    }
+
+    public function test_sans_token_creation_refuse_401(): void
+    {
+        $this->postJson('/api/gerante/clients', [])->assertStatus(401);
+    }
+
+    public function test_admin_ne_peut_pas_lister_clients_gerante_403(): void
+    {
+        $auth = $this->loggedInAdmin();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/gerante/clients')
+            ->assertStatus(403);
+    }
+
+    public function test_admin_ne_peut_pas_creer_client_gerante_403(): void
+    {
+        $auth = $this->loggedInAdmin();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'nom' => 'Test', 'prenom' => 'Test', 'telephone' => '+221771234567',
+            ])
+            ->assertStatus(403);
+    }
+
+    // ─── Liste ───────────────────────────────────────────────────────────────
+
+    public function test_gerante_peut_lister_les_clientes(): void
+    {
+        Client::factory()->count(3)->create();
+
+        $auth = $this->loggedInGerante();
+
+        $response = $this->authenticatedAs($auth)
+            ->getJson('/api/gerante/clients')
+            ->assertOk();
+
+        $response->assertJsonPath('data.total', 3);
+        $response->assertJsonStructure(['data' => ['data', 'total', 'current_page', 'last_page']]);
+    }
+
+    /**
+     * @group pgsql
+     * ilike est specifique a PostgreSQL — ce test ne s execute qu en CI
+     * (connexion pgsql). Sur SQLite il serait en erreur 500.
+     */
+    public function test_recherche_filtre_par_nom(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            $this->markTestSkipped('ilike requiert PostgreSQL.');
+        }
+
+        Client::factory()->create(['nom' => 'Diallo', 'prenom' => 'Aissatou']);
+        Client::factory()->create(['nom' => 'Ndiaye', 'prenom' => 'Fatou']);
+
+        $auth = $this->loggedInGerante();
+
+        $response = $this->authenticatedAs($auth)
+            ->getJson('/api/gerante/clients?search=Diallo')
+            ->assertOk();
+
+        $response->assertJsonPath('data.total', 1);
+        $response->assertJsonPath('data.data.0.nom', 'Diallo');
+    }
+
+    /**
+     * @group pgsql
+     */
+    public function test_recherche_filtre_par_telephone(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            $this->markTestSkipped('ilike requiert PostgreSQL.');
+        }
+
+        Client::factory()->create(['telephone' => '+221771111111']);
+        Client::factory()->create(['telephone' => '+221772222222']);
+
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->getJson('/api/gerante/clients?search=7711')
+            ->assertOk()
+            ->assertJsonPath('data.total', 1);
+    }
+
+    // ─── Show ─────────────────────────────────────────────────────────────────
+
+    public function test_gerante_peut_voir_une_cliente(): void
+    {
+        $client = Client::factory()->create();
+        $auth   = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->getJson("/api/gerante/clients/{$client->id}")
+            ->assertOk()
+            ->assertJsonPath('data.id', $client->id);
+    }
+
+    // ─── Creation ────────────────────────────────────────────────────────────
+
+    public function test_creation_cliente_physique_reussie(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'nom'       => 'Sarr',
+                'prenom'    => 'Mariama',
+                'telephone' => '+221771234560',
+                'email'     => 'mariama@example.com',
+            ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.nom', 'Sarr')
+            ->assertJsonPath('data.prenom', 'Mariama');
+
+        // La source doit etre forcee a physique.
+        $response->assertJsonPath('data.source', 'physique');
+
+        $this->assertDatabaseHas('clients', [
+            'nom'    => 'Sarr',
+            'source' => 'physique',
+        ]);
+    }
+
+    public function test_creation_cree_preferences_par_defaut(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'nom'       => 'Sow',
+                'prenom'    => 'Khady',
+                'telephone' => '+221771234561',
+            ])
+            ->assertStatus(201);
+
+        $clientId = $response->json('data.id');
+
+        $this->assertDatabaseHas('preferences_clients', [
+            'client_id'              => $clientId,
+            'notifications_whatsapp' => true,
+            'notifications_promos'   => true,
+        ]);
+    }
+
+    public function test_source_forcee_a_physique_meme_si_en_ligne_envoye(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'nom'       => 'Ba',
+                'prenom'    => 'Rokhaya',
+                'telephone' => '+221771234562',
+                'source'    => 'en_ligne',
+            ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.source', 'physique');
+    }
+
+    public function test_nombre_reservations_et_fidelite_ignores_a_la_creation(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'nom'                          => 'Fall',
+                'prenom'                       => 'Ndéye',
+                'telephone'                    => '+221771234563',
+                'nombre_reservations_terminees' => 50,
+                'fidelite_disponible'           => true,
+            ])
+            ->assertStatus(201);
+
+        $clientId = $response->json('data.id');
+        $client   = Client::find($clientId);
+
+        // Ces champs ne doivent pas etre modifies par la gerante.
+        $this->assertEquals(0, $client->nombre_reservations_terminees);
+        $this->assertFalse($client->fidelite_disponible);
+    }
+
+    public function test_creation_sans_nom_refuse_422(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'prenom'    => 'Mariama',
+                'telephone' => '+221771234564',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['nom']);
+    }
+
+    public function test_creation_telephone_invalide_refuse_422(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'nom'       => 'Test',
+                'prenom'    => 'Test',
+                'telephone' => '0612345678',  // pas en E.164 international
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['telephone']);
+    }
+
+    public function test_creation_telephone_duplique_refuse_422(): void
+    {
+        Client::factory()->create(['telephone' => '+221771234565']);
+
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'nom'       => 'Autre',
+                'prenom'    => 'Autre',
+                'telephone' => '+221771234565',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['telephone']);
+    }
+
+    // ─── Modification ─────────────────────────────────────────────────────────
+
+    public function test_gerante_peut_modifier_les_coordonnees(): void
+    {
+        $client = Client::factory()->create([
+            'nom'       => 'Ancien',
+            'prenom'    => 'Nom',
+            'telephone' => '+221771234566',
+        ]);
+
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->putJson("/api/gerante/clients/{$client->id}", [
+                'nom'    => 'Nouveau',
+                'prenom' => 'Prenom',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.nom', 'Nouveau')
+            ->assertJsonPath('data.prenom', 'Prenom');
+    }
+
+    public function test_modification_ne_peut_pas_changer_source(): void
+    {
+        $client = Client::factory()->create(['source' => 'physique']);
+        $auth   = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->putJson("/api/gerante/clients/{$client->id}", [
+                'source' => 'en_ligne',
+            ])
+            ->assertOk();
+
+        // La source ne doit pas avoir change.
+        $this->assertSame('physique', Client::find($client->id)->source);
+    }
+
+    public function test_modification_telephone_duplique_refuse_422(): void
+    {
+        $existing = Client::factory()->create(['telephone' => '+221771234567']);
+        $target   = Client::factory()->create(['telephone' => '+221771234568']);
+
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->putJson("/api/gerante/clients/{$target->id}", [
+                'telephone' => $existing->telephone,
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['telephone']);
+    }
+
+    // ─── Logs ─────────────────────────────────────────────────────────────────
+
+    public function test_creation_cree_un_log_systeme(): void
+    {
+        $auth = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/clients', [
+                'nom'       => 'Logtest',
+                'prenom'    => 'Prenom',
+                'telephone' => '+221771234569',
+            ])
+            ->assertStatus(201);
+
+        $this->assertDatabaseHas('logs_systeme', [
+            'action' => 'gerante_creation_client',
+            'module' => 'clients',
+        ]);
+    }
+
+    public function test_modification_cree_un_log_avec_before_after(): void
+    {
+        $client = Client::factory()->create(['nom' => 'Avant', 'prenom' => 'Prenom']);
+        $auth   = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->putJson("/api/gerante/clients/{$client->id}", ['nom' => 'Apres'])
+            ->assertOk();
+
+        $log = LogSysteme::where('action', 'gerante_modification_client')->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('Avant', $log->before['nom']);
+        $this->assertSame('Apres', $log->after['nom']);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ const SettingsPage = lazy(() => import('./features/admin/settings/SettingsPage')
 const PromotionsPage = lazy(() => import('./features/admin/promotions/PromotionsPage'))
 const LogsPage = lazy(() => import('./features/admin/logs-systeme/LogsPage'))
 const GeranteReservationsPage = lazy(() => import('./features/gerante/GeranteReservationsPage'))
+const GeranteClientsPage = lazy(() => import('./features/gerante/GeranteClientsPage'))
 
 function NotFound() {
   return (
@@ -106,6 +107,16 @@ function App() {
           <RequireAuth role="gerante">
             <Suspense fallback={<RouteSuspenseFallback />}>
               <GeranteReservationsPage />
+            </Suspense>
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/manager/clients"
+        element={
+          <RequireAuth role="gerante">
+            <Suspense fallback={<RouteSuspenseFallback />}>
+              <GeranteClientsPage />
             </Suspense>
           </RequireAuth>
         }

--- a/frontend/src/features/gerante/GeranteClientsPage.tsx
+++ b/frontend/src/features/gerante/GeranteClientsPage.tsx
@@ -1,0 +1,409 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AlertCircle, Plus, RefreshCw, Search, UserRound, X } from 'lucide-react'
+import GeranteLayout from '../../layouts/GeranteLayout'
+import {
+  createGeranteClient,
+  getGeranteClients,
+  updateGeranteClient,
+  type GeranteClientForm,
+} from './clients.api'
+import type { Client, LaravelPaginated } from '../admin/clients/clients.types'
+
+// ── Utilitaires ───────────────────────────────────────────────────────────────
+
+function clientFullName(c: Client) {
+  return `${c.prenom} ${c.nom}`.trim()
+}
+
+function emptyForm(): GeranteClientForm {
+  return { nom: '', prenom: '', telephone: '', email: '' }
+}
+
+// ── Modal creation / edition ──────────────────────────────────────────────────
+
+type ClientModalProps = {
+  initial?: Client
+  onClose: () => void
+  onSaved: (client: Client) => void
+}
+
+function ClientModal({ initial, onClose, onSaved }: ClientModalProps) {
+  const [form, setForm] = useState<GeranteClientForm>(
+    initial
+      ? { nom: initial.nom, prenom: initial.prenom, telephone: initial.telephone, email: initial.email ?? '' }
+      : emptyForm(),
+  )
+  const [loading, setLoading] = useState(false)
+  const [errors, setErrors] = useState<Record<string, string[]>>({})
+
+  const isEdit = Boolean(initial)
+
+  function field(key: keyof GeranteClientForm) {
+    return {
+      value: form[key],
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+        setForm((prev) => ({ ...prev, [key]: e.target.value })),
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setErrors({})
+    setLoading(true)
+
+    try {
+      const saved = isEdit
+        ? await updateGeranteClient(initial!.id, form)
+        : await createGeranteClient(form)
+
+      onSaved(saved)
+    } catch (err: unknown) {
+      const resp = (err as { response?: { data?: { errors?: Record<string, string[]> } } })?.response
+      setErrors(resp?.data?.errors ?? {})
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="font-display text-lg font-bold text-gray-900">
+            {isEdit ? 'Modifier la cliente' : 'Nouvelle cliente'}
+          </h2>
+          <button type="button" onClick={onClose} className="rounded-lg p-1 hover:bg-gray-100">
+            <X className="h-5 w-5 text-gray-500" />
+          </button>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 gap-3">
+            <LabeledInput label="Prenom" required {...field('prenom')} error={errors.prenom?.[0]} />
+            <LabeledInput label="Nom" required {...field('nom')} error={errors.nom?.[0]} />
+          </div>
+          <LabeledInput
+            label="Telephone (ex: +221771234567)"
+            required
+            {...field('telephone')}
+            error={errors.telephone?.[0]}
+            hint="Format international obligatoire"
+          />
+          <LabeledInput
+            label="Email (optionnel)"
+            type="email"
+            {...field('email')}
+            error={errors.email?.[0]}
+          />
+
+          {!isEdit && (
+            <p className="rounded-lg bg-[#fff2f7] px-3 py-2 text-[12px] text-[#c41468]">
+              La source sera automatiquement definie comme <strong>physique</strong> (comptoir).
+            </p>
+          )}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-xl border border-gray-200 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex-1 rounded-xl bg-[#e91e63] py-2 text-sm font-semibold text-white hover:bg-[#c41468] disabled:opacity-60"
+            >
+              {loading ? 'Enregistrement...' : isEdit ? 'Enregistrer' : 'Creer'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+type LabeledInputProps = {
+  label: string
+  error?: string
+  hint?: string
+  required?: boolean
+  type?: string
+  value: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+function LabeledInput({ label, error, hint, required, type = 'text', value, onChange }: LabeledInputProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[12px] font-semibold text-gray-700">
+        {label}
+        {required && <span className="ml-0.5 text-red-500">*</span>}
+      </label>
+      <input
+        type={type}
+        required={required}
+        value={value}
+        onChange={onChange}
+        className={[
+          'rounded-xl border px-3 py-2 text-[13px] outline-none transition focus:ring-2 focus:ring-[#e91e63]/30',
+          error ? 'border-red-400' : 'border-gray-200 focus:border-[#e91e63]',
+        ].join(' ')}
+      />
+      {hint && !error && <p className="text-[11px] text-gray-400">{hint}</p>}
+      {error && <p className="text-[11px] text-red-500">{error}</p>}
+    </div>
+  )
+}
+
+// ── Page principale ───────────────────────────────────────────────────────────
+
+function GeranteClientsPage() {
+  const [page, setPage] = useState<LaravelPaginated<Client> | null>(null)
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [modal, setModal] = useState<{ open: boolean; client?: Client }>({ open: false })
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const load = useCallback(async (q: string, pageNum = 1) => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const result = await getGeranteClients({ search: q || undefined, page: pageNum, per_page: 20 })
+      setPage(result)
+    } catch {
+      setError('Impossible de charger les clientes.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load(search, 1)
+  }, [load, search])
+
+  function handleSearch(value: string) {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setSearch(value)
+    }, 300)
+  }
+
+  function handleSaved(client: Client) {
+    setModal({ open: false })
+    // Mise a jour optimiste : on recharge la liste.
+    void load(search, page?.current_page ?? 1)
+
+    // Le client cree/modifie remonte en tete du prochain chargement (latest()).
+    void client
+  }
+
+  return (
+    <GeranteLayout>
+      <div className="flex flex-col gap-5">
+        {/* En-tete */}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="font-display text-2xl font-bold text-gray-900">Clientes</h1>
+            <p className="mt-0.5 text-[13px] text-gray-500">
+              {page ? `${page.total} cliente${page.total > 1 ? 's' : ''}` : 'Chargement...'}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => void load(search, page?.current_page ?? 1)}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+              title="Actualiser"
+            >
+              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            </button>
+            <button
+              type="button"
+              onClick={() => setModal({ open: true })}
+              className="flex items-center gap-2 rounded-xl bg-[#e91e63] px-4 py-2 text-[13px] font-semibold text-white hover:bg-[#c41468]"
+            >
+              <Plus className="h-4 w-4" />
+              Nouvelle cliente
+            </button>
+          </div>
+        </div>
+
+        {/* Barre de recherche */}
+        <div className="relative max-w-sm">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+          <input
+            type="search"
+            placeholder="Nom, prenom, telephone..."
+            onChange={(e) => handleSearch(e.target.value)}
+            className="w-full rounded-xl border border-gray-200 py-2 pl-9 pr-3 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
+          />
+        </div>
+
+        {/* Erreur */}
+        {error && (
+          <div className="flex items-center gap-2 rounded-xl bg-red-50 px-4 py-3 text-[13px] text-red-700">
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {/* Tableau */}
+        <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm">
+          {/* Desktop */}
+          <div className="hidden sm:block">
+            <table className="w-full text-[13px]">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-500">Cliente</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-500">Telephone</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-500">Email</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-500">Source</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-500">Statut</th>
+                  <th className="px-4 py-3" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {page?.data.length === 0 && !loading && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-10 text-center text-gray-400">
+                      Aucune cliente trouvee.
+                    </td>
+                  </tr>
+                )}
+                {page?.data.map((client) => (
+                  <tr key={client.id} className="hover:bg-gray-50/50">
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#fff2f7]">
+                          <UserRound className="h-4 w-4 text-[#e91e63]" />
+                        </div>
+                        <span className="font-semibold text-gray-900">{clientFullName(client)}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 font-mono text-gray-700">{client.telephone}</td>
+                    <td className="px-4 py-3 text-gray-600">{client.email ?? <span className="text-gray-300">—</span>}</td>
+                    <td className="px-4 py-3">
+                      <SourceBadge source={client.source} />
+                    </td>
+                    <td className="px-4 py-3">
+                      {client.est_blackliste ? (
+                        <span className="rounded-full bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700">
+                          Blacklistee
+                        </span>
+                      ) : (
+                        <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+                          Active
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => setModal({ open: true, client })}
+                        className="rounded-lg border border-gray-200 px-3 py-1 text-[12px] font-semibold text-gray-700 hover:bg-gray-50"
+                      >
+                        Modifier
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile cards */}
+          <div className="flex flex-col divide-y divide-gray-100 sm:hidden">
+            {page?.data.length === 0 && !loading && (
+              <p className="px-4 py-10 text-center text-[13px] text-gray-400">Aucune cliente trouvee.</p>
+            )}
+            {page?.data.map((client) => (
+              <div key={client.id} className="flex items-start gap-3 px-4 py-3">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#fff2f7]">
+                  <UserRound className="h-4 w-4 text-[#e91e63]" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-semibold text-gray-900">{clientFullName(client)}</p>
+                  <p className="text-[12px] font-mono text-gray-500">{client.telephone}</p>
+                  {client.email && <p className="text-[12px] text-gray-400">{client.email}</p>}
+                  <div className="mt-1 flex items-center gap-2">
+                    <SourceBadge source={client.source} />
+                    {client.est_blackliste && (
+                      <span className="rounded-full bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700">
+                        Blacklistee
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setModal({ open: true, client })}
+                  className="shrink-0 rounded-lg border border-gray-200 px-3 py-1 text-[12px] font-semibold text-gray-700"
+                >
+                  Modifier
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Pagination */}
+        {page && page.last_page > 1 && (
+          <div className="flex items-center justify-between text-[13px]">
+            <p className="text-gray-500">
+              Page {page.current_page} / {page.last_page}
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={page.current_page === 1}
+                onClick={() => void load(search, page.current_page - 1)}
+                className="rounded-xl border border-gray-200 px-4 py-1.5 font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-40"
+              >
+                Precedent
+              </button>
+              <button
+                type="button"
+                disabled={page.current_page === page.last_page}
+                onClick={() => void load(search, page.current_page + 1)}
+                className="rounded-xl border border-gray-200 px-4 py-1.5 font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-40"
+              >
+                Suivant
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Modal */}
+      {modal.open && (
+        <ClientModal
+          initial={modal.client}
+          onClose={() => setModal({ open: false })}
+          onSaved={handleSaved}
+        />
+      )}
+    </GeranteLayout>
+  )
+}
+
+function SourceBadge({ source }: { source: string }) {
+  if (source === 'physique') {
+    return (
+      <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-700">
+        Physique
+      </span>
+    )
+  }
+
+  return (
+    <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700">
+      En ligne
+    </span>
+  )
+}
+
+export default GeranteClientsPage

--- a/frontend/src/features/gerante/clients.api.ts
+++ b/frontend/src/features/gerante/clients.api.ts
@@ -1,0 +1,67 @@
+import { apiClient } from '../../lib/apiClient'
+import type {
+  ApiCollection,
+  ApiItem,
+  Client,
+  LaravelPaginated,
+} from '../admin/clients/clients.types'
+
+type QueryParams = {
+  page?: number
+  search?: string
+  per_page?: number
+}
+
+type GeranteClientForm = {
+  nom: string
+  prenom: string
+  telephone: string
+  email: string
+}
+
+function collection<T>(payload: ApiCollection<T>): LaravelPaginated<T> {
+  return payload.data
+}
+
+function cleanText(value: string) {
+  const text = value.trim()
+
+  return text === '' ? null : text
+}
+
+function clientPayload(form: GeranteClientForm) {
+  return {
+    nom: form.nom.trim(),
+    prenom: form.prenom.trim(),
+    telephone: form.telephone.trim(),
+    email: cleanText(form.email),
+  }
+}
+
+export async function getGeranteClients(params?: QueryParams) {
+  const response = await apiClient.get<ApiCollection<Client>>('/gerante/clients', {
+    params,
+  })
+
+  return collection(response.data)
+}
+
+export async function getGeranteClient(id: number) {
+  const response = await apiClient.get<ApiItem<Client>>(`/gerante/clients/${id}`)
+
+  return response.data.data
+}
+
+export async function createGeranteClient(form: GeranteClientForm) {
+  const response = await apiClient.post<ApiItem<Client>>('/gerante/clients', clientPayload(form))
+
+  return response.data.data
+}
+
+export async function updateGeranteClient(id: number, form: GeranteClientForm) {
+  const response = await apiClient.put<ApiItem<Client>>(`/gerante/clients/${id}`, clientPayload(form))
+
+  return response.data.data
+}
+
+export type { GeranteClientForm }

--- a/frontend/src/layouts/GeranteLayout.tsx
+++ b/frontend/src/layouts/GeranteLayout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
-import { CalendarDays, LogOut, Menu, X } from 'lucide-react'
+import { CalendarDays, LogOut, Menu, Users, X } from 'lucide-react'
 import { clearAuth, getUser } from '../lib/authStorage'
 import { logout as apiLogout } from '../services/authService'
 
@@ -63,6 +63,21 @@ function GeranteLayout({ children }: GeranteLayoutProps) {
         >
           <CalendarDays className="h-4 w-4 shrink-0" />
           <span className="min-w-0 flex-1 truncate">Reservations</span>
+        </NavLink>
+        <NavLink
+          to="/manager/clients"
+          onClick={closeMobileMenu}
+          className={({ isActive }) =>
+            [
+              'flex items-center gap-3 rounded-xl px-4 py-2 text-[13px] font-semibold transition',
+              isActive
+                ? 'bg-[#e91e63] text-white shadow-[0_14px_30px_-18px_rgba(233,30,99,0.9)]'
+                : 'text-white/85 hover:bg-white/8 hover:text-white',
+            ].join(' ')
+          }
+        >
+          <Users className="h-4 w-4 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">Clientes</span>
         </NavLink>
       </nav>
 


### PR DESCRIPTION
- Backend : GeranteClientController (index/show/store/update)
  - source forcee a physique a la creation
  - champs sensibles bloques (source/fidelite/nombre_reservations) a la modification
  - logs SystemLogger avec before/after sur chaque mutation
  - 4 routes ajoutees sous /api/gerante/clients
- Frontend : GeranteClientsPage + clients.api.ts
  - liste paginee avec recherche
  - modal creation / edition
  - NavLink Clientes dans GeranteLayout
  - route /manager/clients ajoutee dans App.tsx
- Tests : ClientTest (20 cas, 2 skipped ilike/SQLite)