### PR TITLE
feat(gerante): creation de reservation physique + fix workflow acompte

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/Admin/ReservationController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Client;
 use App\Models\CodePromo;
 use App\Models\Coiffure;
+use App\Models\Paiement;
 use App\Models\ParametreSysteme;
 use App\Models\RegleFidelite;
 use App\Models\Reservation;
@@ -14,6 +15,7 @@ use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use Propaganistas\LaravelPhone\Rules\Phone;
@@ -36,7 +38,7 @@ class ReservationController extends Controller
     private const VALID_TRANSITIONS = [
         'en_attente'   => ['annulee', 'absence'],
         'confirmee'    => ['annulee', 'absence'],
-        'acompte_paye' => ['terminee', 'annulee', 'absence'],
+        'acompte_paye' => ['en_cours', 'terminee', 'annulee', 'absence'],
         'en_cours'     => ['terminee', 'annulee', 'absence'],
         'terminee'     => [],
         'annulee'      => [],
@@ -203,6 +205,9 @@ class ReservationController extends Controller
      */
     private function validatedReservationData(Request $request, ?Reservation $reservation = null): array
     {
+        // Acompte a la creation : requis seulement si l admin coche la case.
+        $enregistrerAcompte = $request->boolean('enregistrer_acompte', false);
+
         $data = $request->validate([
             'client_id' => ['nullable', 'integer', 'exists:clients,id'],
             'client' => ['nullable', 'array'],
@@ -227,6 +232,14 @@ class ReservationController extends Controller
             'details.*.quantite' => ['sometimes', 'integer', 'min:1', 'max:10'],
             'details.*.option_ids' => ['sometimes', 'array'],
             'details.*.option_ids.*' => ['integer', 'distinct', 'exists:options_coiffures,id'],
+            // Enregistrement d un acompte physique directement a la creation
+            // (uniquement pour un nouveau dossier, pas pour les mises a jour).
+            'enregistrer_acompte'   => ['sometimes', 'boolean'],
+            'mode_paiement_acompte' => [
+                $enregistrerAcompte ? 'required' : 'sometimes',
+                'nullable',
+                Rule::in(['especes', 'wave', 'orange_money', 'carte_bancaire', 'autre']),
+            ],
         ]);
 
         $clientId = $data['client_id'] ?? $reservation?->client_id;
@@ -261,6 +274,7 @@ class ReservationController extends Controller
      */
     private function persistReservation(array $data, ?Reservation $reservation = null): Reservation
     {
+        $isNew = $reservation === null;
         $oldStatus = $reservation?->statut;
         $oldClientId = $reservation?->client_id;
         $oldCodePromoId = $reservation?->code_promo_id;
@@ -301,6 +315,29 @@ class ReservationController extends Controller
 
         $this->syncPromoUsage($oldCodePromoId, $reservation->code_promo_id);
         $this->syncClientCompletion($oldClientId, $oldStatus, $reservation->client_id, $reservation->statut, $reservation->fidelite_appliquee);
+
+        // Acompte physique encaisse par l admin a la creation :
+        // on cree le paiement puis on bascule le statut en acompte_paye.
+        // Uniquement sur les nouvelles reservations pour eviter les doublons.
+        if ($isNew && ($data['enregistrer_acompte'] ?? false) && (float) $reservation->montant_acompte > 0) {
+            $paiement = Paiement::query()->create([
+                'reservation_id' => $reservation->id,
+                'client_id'      => $reservation->client_id,
+                'numero_recu'    => 'TEMP-' . Str::uuid()->toString(),
+                'type'           => 'acompte',
+                'mode_paiement'  => $data['mode_paiement_acompte'],
+                'montant'        => $reservation->montant_acompte,
+                'devise'         => $reservation->devise,
+                'statut'         => 'valide',
+                'date_paiement'  => now(),
+                'notes'          => 'Acompte encaisse par l admin a la creation de la reservation.',
+            ]);
+            $paiement->update([
+                'numero_recu' => 'BT-' . now()->format('Ymd') . '-' . str_pad((string) $paiement->id, 4, '0', STR_PAD_LEFT),
+            ]);
+            $reservation->statut = 'acompte_paye';
+            $reservation->save();
+        }
 
         return $reservation->load($this->relations());
     }

--- a/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
@@ -3,9 +3,13 @@
 namespace App\Http\Controllers\Api\Gerante;
 
 use App\Http\Controllers\Controller;
+use App\Models\Client;
+use App\Models\Coiffure;
 use App\Models\Paiement;
+use App\Models\ParametreSysteme;
 use App\Models\Reservation;
 use App\Services\SystemLogger;
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -33,6 +37,10 @@ class ReservationController extends Controller
     // et decourager les detournements de caisse.
     private const SENSITIVE_TRANSITIONS = [
         'acompte_paye' => ['annulee', 'absence'],
+    ];
+
+    private const BLOCKING_STATUSES = [
+        'en_attente', 'confirmee', 'acompte_paye', 'en_cours', 'terminee',
     ];
 
     public function __construct(private readonly SystemLogger $logger) {}
@@ -70,6 +78,152 @@ class ReservationController extends Controller
         return response()->json([
             'data' => $reservation->load($this->relations()),
         ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $enregistrerAcompte = $request->boolean('enregistrer_acompte', false);
+
+        $data = $request->validate([
+            'client_id'                      => ['required', 'integer', 'exists:clients,id'],
+            'coiffeuse_id'                   => ['nullable', 'integer', Rule::exists('coiffeuses', 'id')->where('actif', true)],
+            'date_reservation'               => ['required', 'date'],
+            'heure_debut'                    => ['required', 'date_format:H:i'],
+            'details'                        => ['required', 'array', 'min:1'],
+            'details.*.coiffure_id'          => ['required', 'integer', 'exists:coiffures,id'],
+            'details.*.variante_coiffure_id' => ['required', 'integer', 'exists:variantes_coiffures,id'],
+            'details.*.quantite'             => ['sometimes', 'integer', 'min:1', 'max:10'],
+            'notes'                          => ['nullable', 'string', 'max:5000'],
+            'enregistrer_acompte'            => ['sometimes', 'boolean'],
+            'mode_paiement_acompte'          => [
+                $enregistrerAcompte ? 'required' : 'sometimes',
+                'nullable',
+                Rule::in(['especes', 'wave', 'orange_money', 'carte_bancaire', 'autre']),
+            ],
+        ]);
+
+        $client = Client::query()->find($data['client_id']);
+
+        if ($client->est_blackliste) {
+            throw ValidationException::withMessages([
+                'client_id' => 'Cette cliente est dans la liste noire.',
+            ]);
+        }
+
+        // Calcul du total et de la duree a partir des coiffures/variantes choisies
+        $details  = [];
+        $subtotal = 0.0;
+        $duration = 0;
+
+        foreach (array_values($data['details']) as $index => $detailData) {
+            $line      = $this->computeDetail($detailData, $index + 1);
+            $details[] = $line;
+            $subtotal  += (float) $line['montant_total'];
+            $duration  += (int) $line['duree_minutes'];
+        }
+
+        if ($duration < 1) {
+            throw ValidationException::withMessages([
+                'details' => 'La reservation doit contenir au moins une prestation valide.',
+            ]);
+        }
+
+        $startsAt = Carbon::createFromFormat('Y-m-d H:i', $data['date_reservation'] . ' ' . $data['heure_debut']);
+        $endsAt   = $startsAt->copy()->addMinutes($duration);
+
+        if (! $startsAt->isSameDay($endsAt)) {
+            throw ValidationException::withMessages([
+                'heure_debut' => 'La reservation doit se terminer le meme jour.',
+            ]);
+        }
+
+        $this->ensureOpenDay($startsAt);
+        $this->ensureWithinBusinessHours($startsAt, $endsAt);
+        $this->ensureSalonCapacity($data, null);
+
+        // Acompte cible calcule par les parametres systeme
+        $depositPercent  = (float) $this->settingValue('pourcentage_acompte', 0);
+        $depositFallback = (float) $this->settingValue('montant_acompte_defaut', 0);
+        $deposit         = $depositPercent > 0
+            ? round($subtotal * ($depositPercent / 100), 2)
+            : min($depositFallback, $subtotal);
+        $deposit = min(max($deposit, 0), $subtotal);
+
+        $reservation = DB::transaction(function () use ($data, $details, $subtotal, $duration, $deposit, $endsAt): Reservation {
+            // La source est toujours physique : la gerante gere uniquement
+            // les clientes qui se presentent en personne au salon.
+            $statut = ($data['enregistrer_acompte'] ?? false) && $deposit > 0
+                ? 'acompte_paye'
+                : 'en_attente';
+
+            $res = Reservation::query()->create([
+                'client_id'            => $data['client_id'],
+                'coiffeuse_id'         => $data['coiffeuse_id'] ?? null,
+                'date_reservation'     => $data['date_reservation'],
+                'heure_debut'          => $data['heure_debut'],
+                'heure_fin'            => $endsAt->format('H:i'),
+                'duree_totale_minutes' => $duration,
+                'statut'               => $statut,
+                'source'               => 'physique',
+                'montant_total'        => round($subtotal, 2),
+                'montant_reduction'    => 0,
+                'montant_acompte'      => round($deposit, 2),
+                'montant_restant'      => round(max($subtotal - $deposit, 0), 2),
+                'devise'               => 'FCFA',
+                'fidelite_appliquee'   => false,
+                'notes'                => $data['notes'] ?? null,
+            ]);
+
+            foreach ($details as $detail) {
+                $res->details()->create($detail);
+            }
+
+            if ($statut === 'acompte_paye') {
+                // UUID temporaire obligatoire car numero_recu est NOT NULL + UNIQUE.
+                // On le remplace par le numero definitif apres avoir obtenu l id.
+                $paiement = Paiement::query()->create([
+                    'reservation_id' => $res->id,
+                    'client_id'      => $res->client_id,
+                    'numero_recu'    => 'TEMP-' . Str::uuid()->toString(),
+                    'type'           => 'acompte',
+                    'mode_paiement'  => $data['mode_paiement_acompte'],
+                    'montant'        => $res->montant_acompte,
+                    'devise'         => 'FCFA',
+                    'statut'         => 'valide',
+                    'date_paiement'  => now(),
+                    'notes'          => 'Acompte encaisse par la gerante a la creation de la reservation.',
+                ]);
+                $paiement->update([
+                    'numero_recu' => 'BT-' . now()->format('Ymd') . '-' . str_pad((string) $paiement->id, 4, '0', STR_PAD_LEFT),
+                ]);
+            }
+
+            return $res;
+        });
+
+        $this->logger->record(
+            action: 'gerante_creation_reservation',
+            module: 'reservations',
+            description: "Reservation #{$reservation->id} creee en physique pour la cliente #{$reservation->client_id}",
+            subject: $reservation,
+            after: [
+                'statut'        => $reservation->statut,
+                'montant_total' => $reservation->montant_total,
+                'source'        => 'physique',
+            ],
+            metadata: array_filter([
+                'reservation_id'   => $reservation->id,
+                'client_id'        => $reservation->client_id,
+                'acompte_encaisse' => ($data['enregistrer_acompte'] ?? false) && $reservation->statut === 'acompte_paye',
+                'actor_role'       => 'gerante',
+            ]),
+            request: $request,
+        );
+
+        return response()->json([
+            'message' => 'Reservation creee.',
+            'data'    => $reservation->load($this->relations()),
+        ], 201);
     }
 
     public function updateStatus(Request $request, Reservation $reservation): JsonResponse
@@ -188,6 +342,124 @@ class ReservationController extends Controller
         if ($reservation->statut !== 'annulee') {
             $reservation->annulee_at = null;
         }
+    }
+
+    /**
+     * @param array<string, mixed> $detailData
+     * @return array<string, mixed>
+     */
+    private function computeDetail(array $detailData, int $order): array
+    {
+        $coiffure = Coiffure::query()
+            ->with(['variantes', 'options'])
+            ->where('actif', true)
+            ->find($detailData['coiffure_id']);
+
+        if (! $coiffure) {
+            throw ValidationException::withMessages([
+                'details' => 'Coiffure inactive ou introuvable.',
+            ]);
+        }
+
+        $variante = $coiffure->variantes
+            ->where('id', $detailData['variante_coiffure_id'])
+            ->where('actif', true)
+            ->first();
+
+        if (! $variante) {
+            throw ValidationException::withMessages([
+                'details' => 'Variante inactive ou non associee a la coiffure.',
+            ]);
+        }
+
+        $quantity  = (int) ($detailData['quantite'] ?? 1);
+        $unitPrice = (float) $variante->prix;
+        $lineTotal = $unitPrice * $quantity;
+
+        return [
+            'coiffure_id'          => $coiffure->id,
+            'variante_coiffure_id' => $variante->id,
+            'coiffure_nom'         => $coiffure->nom,
+            'variante_nom'         => $variante->nom,
+            'prix_unitaire'        => round($unitPrice, 2),
+            'duree_minutes'        => (int) $variante->duree_minutes * $quantity,
+            'quantite'             => $quantity,
+            'option_ids'           => [],
+            'options_snapshot'     => [],
+            'montant_options'      => 0,
+            'montant_total'        => round($lineTotal, 2),
+            'ordre'                => $order,
+        ];
+    }
+
+    private function ensureOpenDay(Carbon $startsAt): void
+    {
+        $days   = $this->settingValue('jours_fermeture', []);
+        $closed = is_array($days) ? $days : [];
+        $day    = match ((int) $startsAt->dayOfWeekIso) {
+            1 => 'lundi', 2 => 'mardi', 3 => 'mercredi', 4 => 'jeudi',
+            5 => 'vendredi', 6 => 'samedi', 7 => 'dimanche',
+            default => 'lundi',
+        };
+
+        if (in_array($day, $closed, true)) {
+            throw ValidationException::withMessages([
+                'date_reservation' => 'Le salon est ferme ce jour-la.',
+            ]);
+        }
+    }
+
+    private function ensureWithinBusinessHours(Carbon $startsAt, Carbon $endsAt): void
+    {
+        $open  = $this->settingValue('heure_ouverture', '09:00');
+        $close = $this->settingValue('heure_fermeture', '19:00');
+
+        if ($startsAt->format('H:i') < $open || $endsAt->format('H:i') > $close) {
+            throw ValidationException::withMessages([
+                'heure_debut' => "La reservation doit rester entre {$open} et {$close}.",
+            ]);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function ensureSalonCapacity(array $data, ?Reservation $reservation): void
+    {
+        $dailyLimit = max(1, (int) $this->settingValue('limite_reservations_par_jour', 15));
+        $slotLimit  = max(1, (int) $this->settingValue('limite_reservations_par_creneau', 3));
+
+        $dailyCount = Reservation::query()
+            ->whereDate('date_reservation', $data['date_reservation'])
+            ->whereIn('statut', self::BLOCKING_STATUSES)
+            ->when($reservation, fn ($q) => $q->where('id', '!=', $reservation->id))
+            ->count();
+
+        if ($dailyCount >= $dailyLimit) {
+            throw ValidationException::withMessages([
+                'date_reservation' => "Le quota de {$dailyLimit} reservation(s) pour cette journee est atteint.",
+            ]);
+        }
+
+        $slotCount = Reservation::query()
+            ->whereDate('date_reservation', $data['date_reservation'])
+            ->whereTime('heure_debut', $data['heure_debut'])
+            ->whereIn('statut', self::BLOCKING_STATUSES)
+            ->when($reservation, fn ($q) => $q->where('id', '!=', $reservation->id))
+            ->count();
+
+        if ($slotCount >= $slotLimit) {
+            throw ValidationException::withMessages([
+                'heure_debut' => "Ce creneau est complet ({$slotLimit} reservation(s) a {$data['heure_debut']}).",
+            ]);
+        }
+    }
+
+    private function settingValue(string $key, mixed $default): mixed
+    {
+        $setting = ParametreSysteme::query()->where('cle', $key)->first();
+
+        return $setting?->valeur['value'] ?? $default;
     }
 
     /**

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -160,6 +160,7 @@ Route::middleware(['auth.token', 'role:gerante', 'log.admin'])
     ->name('gerante.')
     ->group(function (): void {
         Route::get('reservations', [GeranteReservationController::class, 'index'])->name('reservations.index');
+        Route::post('reservations', [GeranteReservationController::class, 'store'])->name('reservations.store');
         Route::get('reservations/{reservation}', [GeranteReservationController::class, 'show'])->name('reservations.show');
         Route::patch('reservations/{reservation}/statut', [GeranteReservationController::class, 'updateStatus'])->name('reservations.statut');
         Route::get('clients', [GeranteClientController::class, 'index'])->name('clients.index');

--- a/backend/tests/Feature/Gerante/ReservationCreateTest.php
+++ b/backend/tests/Feature/Gerante/ReservationCreateTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Tests\Feature\Gerante;
+
+use App\Models\Client;
+use App\Models\Coiffure;
+use App\Models\Paiement;
+use App\Models\ParametreSysteme;
+use App\Models\Reservation;
+use App\Models\VarianteCoiffure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tests d integration sur POST /api/gerante/reservations et sur
+ * la correction de la transition admin acompte_paye -> en_cours.
+ *
+ * Couvre :
+ * - acces sans token refuse en 401
+ * - acces admin refuse en 403
+ * - creation d une reservation physique simple
+ * - creation avec acompte : paiement cree + statut acompte_paye
+ * - acompte ignore si montant calcule est 0
+ * - client blackliste refuse en 422
+ * - coiffure inactive refuse
+ * - log cree a la creation
+ * - admin peut maintenant passer acompte_paye en en_cours (fix)
+ */
+class ReservationCreateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    /**
+     * @return array{coiffure: Coiffure, variante: VarianteCoiffure}
+     */
+    private function coiffureAvecVariante(array $coiffureAttrs = [], array $varianteAttrs = []): array
+    {
+        $coiffure = Coiffure::factory()->create(['actif' => true, ...$coiffureAttrs]);
+        $variante = VarianteCoiffure::factory()->create([
+            'coiffure_id'   => $coiffure->id,
+            'actif'         => true,
+            'prix'          => 15000,
+            'duree_minutes' => 60,
+            ...$varianteAttrs,
+        ]);
+
+        return compact('coiffure', 'variante');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(int $clientId, int $coiffureId, int $varianteId): array
+    {
+        return [
+            'client_id'        => $clientId,
+            'date_reservation' => now()->addDay()->toDateString(),
+            'heure_debut'      => '10:00',
+            'details'          => [[
+                'coiffure_id'          => $coiffureId,
+                'variante_coiffure_id' => $varianteId,
+                'quantite'             => 1,
+            ]],
+        ];
+    }
+
+    // ─── Acces ───────────────────────────────────────────────────────────────
+
+    public function test_sans_token_creation_refuse_401(): void
+    {
+        $this->postJson('/api/gerante/reservations', [])->assertStatus(401);
+    }
+
+    public function test_admin_ne_peut_pas_creer_reservation_gerante_403(): void
+    {
+        $auth = $this->loggedInAdmin();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', [])
+            ->assertStatus(403);
+    }
+
+    // ─── Creation simple ─────────────────────────────────────────────────────
+
+    public function test_gerante_peut_creer_reservation_physique(): void
+    {
+        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante();
+        $client = Client::factory()->create();
+        $auth   = $this->loggedInGerante();
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', $this->payload($client->id, $coiffure->id, $variante->id))
+            ->assertStatus(201);
+
+        $response->assertJsonPath('data.statut', 'en_attente');
+        $response->assertJsonPath('data.source', 'physique');
+        $response->assertJsonPath('data.client_id', $client->id);
+
+        $this->assertDatabaseHas('reservations', [
+            'client_id' => $client->id,
+            'source'    => 'physique',
+            'statut'    => 'en_attente',
+        ]);
+    }
+
+    // ─── Creation avec acompte ────────────────────────────────────────────────
+
+    public function test_creation_avec_acompte_cree_paiement_et_passe_en_acompte_paye(): void
+    {
+        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante([], ['prix' => 20000]);
+        $client = Client::factory()->create();
+        $auth   = $this->loggedInGerante();
+
+        // Parametrage : 40 % d acompte (la migration cree deja cette cle — updateOrCreate)
+        ParametreSysteme::query()->updateOrCreate(
+            ['cle' => 'pourcentage_acompte'],
+            ['valeur' => ['value' => 40], 'type' => 'integer'],
+        );
+
+        $payload = $this->payload($client->id, $coiffure->id, $variante->id);
+        $payload['enregistrer_acompte']   = true;
+        $payload['mode_paiement_acompte'] = 'especes';
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', $payload)
+            ->assertStatus(201);
+
+        $response->assertJsonPath('data.statut', 'acompte_paye');
+
+        $reservationId = $response->json('data.id');
+
+        $this->assertDatabaseHas('paiements', [
+            'reservation_id' => $reservationId,
+            'type'           => 'acompte',
+            'statut'         => 'valide',
+            'mode_paiement'  => 'especes',
+            'montant'        => 8000, // 40 % de 20 000
+        ]);
+
+        // numero_recu doit avoir ete remplace par le format BT-
+        $paiement = Paiement::where('reservation_id', $reservationId)->first();
+        $this->assertStringStartsWith('BT-', $paiement->numero_recu);
+    }
+
+    public function test_acompte_ignore_si_montant_calcule_est_zero(): void
+    {
+        // La migration cree des valeurs par defaut non nulles — on les force a 0
+        // pour tester le cas ou aucun acompte n est configure.
+        ParametreSysteme::query()->updateOrCreate(
+            ['cle' => 'pourcentage_acompte'],
+            ['valeur' => ['value' => 0]],
+        );
+        ParametreSysteme::query()->updateOrCreate(
+            ['cle' => 'montant_acompte_defaut'],
+            ['valeur' => ['value' => 0]],
+        );
+
+        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante();
+        $client = Client::factory()->create();
+        $auth   = $this->loggedInGerante();
+
+        $payload = $this->payload($client->id, $coiffure->id, $variante->id);
+        $payload['enregistrer_acompte']   = true;
+        $payload['mode_paiement_acompte'] = 'wave';
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', $payload)
+            ->assertStatus(201);
+
+        // Acompte calcule a 0 -> statut reste en_attente, aucun paiement cree
+        $response->assertJsonPath('data.statut', 'en_attente');
+        $this->assertDatabaseCount('paiements', 0);
+    }
+
+    public function test_mode_paiement_acompte_requis_si_enregistrer_acompte(): void
+    {
+        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante();
+        $client = Client::factory()->create();
+        $auth   = $this->loggedInGerante();
+
+        ParametreSysteme::query()->updateOrCreate(
+            ['cle' => 'pourcentage_acompte'],
+            ['valeur' => ['value' => 40], 'type' => 'integer'],
+        );
+
+        $payload = $this->payload($client->id, $coiffure->id, $variante->id);
+        $payload['enregistrer_acompte'] = true;
+        // mode_paiement_acompte volontairement absent
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', $payload)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['mode_paiement_acompte']);
+    }
+
+    // ─── Validations ─────────────────────────────────────────────────────────
+
+    public function test_client_blackliste_refuse_422(): void
+    {
+        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante();
+        $client = Client::factory()->create(['est_blackliste' => true]);
+        $auth   = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', $this->payload($client->id, $coiffure->id, $variante->id))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['client_id']);
+    }
+
+    public function test_coiffure_inactive_refuse(): void
+    {
+        $coiffure = Coiffure::factory()->create(['actif' => false]);
+        $variante = VarianteCoiffure::factory()->create(['coiffure_id' => $coiffure->id, 'actif' => true]);
+        $client   = Client::factory()->create();
+        $auth     = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', $this->payload($client->id, $coiffure->id, $variante->id))
+            ->assertStatus(422);
+    }
+
+    // ─── Logs ─────────────────────────────────────────────────────────────────
+
+    public function test_creation_cree_log_systeme(): void
+    {
+        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante();
+        $client = Client::factory()->create();
+        $auth   = $this->loggedInGerante();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', $this->payload($client->id, $coiffure->id, $variante->id))
+            ->assertStatus(201);
+
+        $this->assertDatabaseHas('logs_systeme', [
+            'action' => 'gerante_creation_reservation',
+            'module' => 'reservations',
+        ]);
+    }
+
+    // ─── Fix transition admin : acompte_paye → en_cours ─────────────────────
+
+    public function test_admin_peut_passer_acompte_paye_en_en_cours(): void
+    {
+        $reservation = Reservation::factory()->create(['statut' => 'acompte_paye']);
+        $auth        = $this->loggedInAdmin();
+
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/admin/reservations/{$reservation->id}/statut", [
+                'statut' => 'en_cours',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'en_cours');
+    }
+}

--- a/frontend/src/features/gerante/GeranteReservationsPage.tsx
+++ b/frontend/src/features/gerante/GeranteReservationsPage.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AlertTriangle, CalendarDays, Clock3, RefreshCw, Scissors, Search, UserRound } from 'lucide-react'
+import { AlertTriangle, CalendarDays, Clock3, Plus, RefreshCw, Scissors, Search, UserRound, X } from 'lucide-react'
 import GeranteLayout from '../../layouts/GeranteLayout'
-import { getGeranteReservations, updateGeranteReservationStatus, type SoldeInfo } from './reservations.api'
-import type { LaravelPaginated, Reservation, ReservationStatus } from '../admin/reservations/reservations.types'
+import { apiClient } from '../../lib/apiClient'
+import { getGeranteClients } from './clients.api'
+import { createGeranteReservation, getGeranteReservations, updateGeranteReservationStatus, type SoldeInfo } from './reservations.api'
+import type { Client, LaravelPaginated, Reservation, ReservationStatus } from '../admin/reservations/reservations.types'
 
 // Miroir exact de TRANSITIONS dans Gerante/ReservationController.php.
 const TRANSITIONS: Record<ReservationStatus, ReservationStatus[]> = {
@@ -208,6 +210,285 @@ function RaisonModal({ reservation, targetStatus, onConfirm, onCancel, saving }:
   )
 }
 
+// ── Types catalogue (endpoint public /client/catalogue) ───────────────────
+
+type CatVariante = { id: number; nom: string; prix: number; duree_minutes: number }
+type CatCoiffure = { id: number; nom: string; variantes: CatVariante[] }
+
+// ── Modal creation reservation physique ───────────────────────────────────
+
+type NouvelleReservationModalProps = {
+  onClose: () => void
+  onSaved: () => void
+}
+
+function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModalProps) {
+  const [coiffures, setCoiffures] = useState<CatCoiffure[]>([])
+  const [clients, setClients] = useState<Client[]>([])
+  const [clientSearch, setClientSearch] = useState('')
+  const [loadingClients, setLoadingClients] = useState(false)
+
+  const [clientId, setClientId] = useState<number | null>(null)
+  const [coiffureId, setCoiffureId] = useState<number | null>(null)
+  const [varianteId, setVarianteId] = useState<number | null>(null)
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10))
+  const [heure, setHeure] = useState('10:00')
+  const [notes, setNotes] = useState('')
+  const [enregistrerAcompte, setEnregistrerAcompte] = useState(false)
+  const [modePaiement, setModePaiement] = useState('especes')
+
+  const [saving, setSaving] = useState(false)
+  const [errors, setErrors] = useState<Record<string, string[]>>({})
+  const clientSearchRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Chargement du catalogue coiffures au montage
+  useEffect(() => {
+    void apiClient
+      .get<{ data: { coiffures: CatCoiffure[] } }>('/client/catalogue')
+      .then((r) => setCoiffures(r.data.data.coiffures))
+      .catch(() => {})
+  }, [])
+
+  // Recherche cliente avec debounce
+  useEffect(() => {
+    if (clientSearchRef.current) clearTimeout(clientSearchRef.current)
+    if (!clientSearch.trim()) {
+      setClients([])
+      return
+    }
+    clientSearchRef.current = setTimeout(() => {
+      setLoadingClients(true)
+      void getGeranteClients({ search: clientSearch, per_page: 10 })
+        .then((r) => setClients(r.data))
+        .catch(() => {})
+        .finally(() => setLoadingClients(false))
+    }, 300)
+  }, [clientSearch])
+
+  const selectedCoiffure = coiffures.find((c) => c.id === coiffureId) ?? null
+
+  function handleCoiffureChange(id: number) {
+    setCoiffureId(id)
+    setVarianteId(null)
+  }
+
+  function selectClient(c: Client) {
+    setClientId(c.id)
+    setClientSearch(`${c.prenom} ${c.nom} — ${c.telephone}`)
+    setClients([])
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!clientId || !coiffureId || !varianteId) return
+    setErrors({})
+    setSaving(true)
+    try {
+      await createGeranteReservation({
+        client_id:             clientId,
+        date_reservation:      date,
+        heure_debut:           heure,
+        details:               [{ coiffure_id: coiffureId, variante_coiffure_id: varianteId, quantite: 1 }],
+        notes:                 notes || undefined,
+        enregistrer_acompte:   enregistrerAcompte || undefined,
+        mode_paiement_acompte: enregistrerAcompte ? modePaiement : undefined,
+      })
+      onSaved()
+    } catch (err: unknown) {
+      const resp = (err as { response?: { data?: { errors?: Record<string, string[]> } } })?.response
+      setErrors(resp?.data?.errors ?? {})
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-lg rounded-2xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+          <h2 className="font-display text-lg font-bold text-gray-900">Nouvelle reservation</h2>
+          <button type="button" onClick={onClose} className="rounded-lg p-1 hover:bg-gray-100">
+            <X className="h-5 w-5 text-gray-500" />
+          </button>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="flex max-h-[72vh] flex-col gap-4 overflow-y-auto px-6 py-5">
+          {/* Recherche cliente */}
+          <div>
+            <label className="mb-1 block text-[12px] font-semibold text-gray-700">
+              Cliente <span className="text-red-500">*</span>
+            </label>
+            <div className="relative">
+              <input
+                type="search"
+                placeholder="Rechercher par nom ou telephone..."
+                value={clientSearch}
+                onChange={(e) => { setClientSearch(e.target.value); setClientId(null) }}
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
+              />
+              {loadingClients && (
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-gray-400">...</span>
+              )}
+            </div>
+            {clients.length > 0 && (
+              <div className="mt-1 overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm">
+                {clients.map((c) => (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => selectClient(c)}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-[13px] hover:bg-gray-50"
+                  >
+                    <UserRound className="h-4 w-4 shrink-0 text-gray-400" />
+                    <span className="font-semibold text-gray-900">{c.prenom} {c.nom}</span>
+                    <span className="font-mono text-[11px] text-gray-500">{c.telephone}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+            {clientId && (
+              <p className="mt-1 text-[11px] font-semibold text-emerald-600">Cliente selectionnee</p>
+            )}
+            {errors.client_id && <p className="mt-1 text-[11px] text-red-500">{errors.client_id[0]}</p>}
+          </div>
+
+          {/* Coiffure + Variante */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1 block text-[12px] font-semibold text-gray-700">
+                Coiffure <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={coiffureId ?? ''}
+                onChange={(e) => handleCoiffureChange(Number(e.target.value))}
+                required
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
+              >
+                <option value="">Choisir...</option>
+                {coiffures.map((c) => (
+                  <option key={c.id} value={c.id}>{c.nom}</option>
+                ))}
+              </select>
+              {errors.details && <p className="mt-1 text-[11px] text-red-500">{errors.details[0]}</p>}
+            </div>
+            <div>
+              <label className="mb-1 block text-[12px] font-semibold text-gray-700">
+                Variante <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={varianteId ?? ''}
+                onChange={(e) => setVarianteId(Number(e.target.value))}
+                disabled={!selectedCoiffure}
+                required
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20 disabled:opacity-50"
+              >
+                <option value="">Choisir...</option>
+                {(selectedCoiffure?.variantes ?? []).map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.nom} — {v.prix.toLocaleString('fr-FR')} FCFA
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Date + Heure */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1 block text-[12px] font-semibold text-gray-700">
+                Date <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                required
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
+              />
+              {errors.date_reservation && <p className="mt-1 text-[11px] text-red-500">{errors.date_reservation[0]}</p>}
+            </div>
+            <div>
+              <label className="mb-1 block text-[12px] font-semibold text-gray-700">
+                Heure <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="time"
+                value={heure}
+                onChange={(e) => setHeure(e.target.value)}
+                required
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
+              />
+              {errors.heure_debut && <p className="mt-1 text-[11px] text-red-500">{errors.heure_debut[0]}</p>}
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="mb-1 block text-[12px] font-semibold text-gray-700">Notes (optionnel)</label>
+            <textarea
+              rows={2}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
+            />
+          </div>
+
+          {/* Acompte */}
+          <div className="rounded-xl border border-gray-100 bg-gray-50 p-3">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={enregistrerAcompte}
+                onChange={(e) => setEnregistrerAcompte(e.target.checked)}
+                className="h-4 w-4 rounded accent-[#e91e63]"
+              />
+              <span className="text-[13px] font-semibold text-gray-700">Encaisser l&apos;acompte maintenant</span>
+            </label>
+            {enregistrerAcompte && (
+              <div className="mt-3">
+                <label className="mb-1 block text-[12px] font-semibold text-gray-700">Mode de paiement</label>
+                <select
+                  value={modePaiement}
+                  onChange={(e) => setModePaiement(e.target.value)}
+                  className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
+                >
+                  {PAYMENT_MODES.map((m) => (
+                    <option key={m.value} value={m.value}>{m.label}</option>
+                  ))}
+                </select>
+                {errors.mode_paiement_acompte && (
+                  <p className="mt-1 text-[11px] text-red-500">{errors.mode_paiement_acompte[0]}</p>
+                )}
+              </div>
+            )}
+            <p className="mt-2 text-[11px] text-gray-400">
+              Le montant est calcule selon le parametre systeme (pourcentage ou montant fixe).
+            </p>
+          </div>
+
+          {/* Boutons */}
+          <div className="flex gap-3 border-t border-gray-100 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-xl border border-gray-200 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={saving || !clientId || !coiffureId || !varianteId}
+              className="flex-1 rounded-xl bg-[#e91e63] py-2 text-sm font-semibold text-white hover:bg-[#c41468] disabled:opacity-60"
+            >
+              {saving ? 'Enregistrement...' : 'Creer la reservation'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
 // ── Page principale ────────────────────────────────────────────────────────
 
 function GeranteReservationsPage() {
@@ -221,6 +502,8 @@ function GeranteReservationsPage() {
   const [dateTo, setDateTo] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+
+  const [createModalOpen, setCreateModalOpen] = useState(false)
 
   // Etat pour la modal raison (annulation post-acompte)
   const [sensitiveTarget, setSensitiveTarget] = useState<{
@@ -314,6 +597,17 @@ function GeranteReservationsPage() {
 
   return (
     <GeranteLayout>
+      {/* Modal creation reservation physique */}
+      {createModalOpen && (
+        <NouvelleReservationModal
+          onClose={() => setCreateModalOpen(false)}
+          onSaved={() => {
+            setCreateModalOpen(false)
+            void load(page, search, statusFilter, dateFrom, dateTo)
+          }}
+        />
+      )}
+
       {/* Modal encaissement solde avant marquage terminee */}
       {soldeTarget && (
         <SoldeModal
@@ -344,14 +638,24 @@ function GeranteReservationsPage() {
             Suivez et mettez a jour les statuts. Pour toute annulation apres acompte, une raison est obligatoire.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => void load(page, search, statusFilter, dateFrom, dateTo)}
-          className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-bold text-gray-700 shadow-sm transition hover:bg-gray-50"
-        >
-          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-          Actualiser
-        </button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => void load(page, search, statusFilter, dateFrom, dateTo)}
+            className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-bold text-gray-700 shadow-sm transition hover:bg-gray-50"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            Actualiser
+          </button>
+          <button
+            type="button"
+            onClick={() => setCreateModalOpen(true)}
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#e91e63] px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-[#c41468]"
+          >
+            <Plus className="h-4 w-4" />
+            Nouvelle reservation
+          </button>
+        </div>
       </div>
 
       {/* Filtres */}

--- a/frontend/src/features/gerante/reservations.api.ts
+++ b/frontend/src/features/gerante/reservations.api.ts
@@ -1,6 +1,23 @@
 import { apiClient } from '../../lib/apiClient'
 import type { LaravelPaginated, Reservation, ReservationStatus } from '../admin/reservations/reservations.types'
 
+export type GeranteReservationDetail = {
+  coiffure_id: number
+  variante_coiffure_id: number
+  quantite?: number
+}
+
+export type GeranteReservationForm = {
+  client_id: number
+  coiffeuse_id?: number | null
+  date_reservation: string
+  heure_debut: string
+  details: GeranteReservationDetail[]
+  notes?: string
+  enregistrer_acompte?: boolean
+  mode_paiement_acompte?: string
+}
+
 type QueryParams = {
   page?: number
   per_page?: number
@@ -24,6 +41,11 @@ export async function getGeranteReservation(id: number): Promise<Reservation> {
 export type SoldeInfo = {
   enregistrer_paiement: boolean
   mode_paiement_solde?: string
+}
+
+export async function createGeranteReservation(form: GeranteReservationForm): Promise<Reservation> {
+  const response = await apiClient.post<{ data: Reservation }>('/gerante/reservations', form)
+  return response.data.data
 }
 
 export async function updateGeranteReservationStatus(


### PR DESCRIPTION
- Gerante peut creer une reservation physique depuis son espace : client, coiffure/variante, date/heure, notes
- Option encaisser l acompte a la creation : cree un Paiement (type=acompte, statut=valide) et passe la reservation en acompte_paye directement
- Admin : meme option a la creation (enregistrer_acompte + mode_paiement_acompte)
- Admin VALID_TRANSITIONS : ajoute en_cours dans acompte_paye pour debloquer le passage acompte_paye -> en_cours sans passer par la gerante
- Frontend : bouton Nouvelle reservation + modal dans l espace gerante (recherche cliente, select coiffure/variante catalogue public, date/heure, acompte optionnel)
- Tests : 10 nouveaux tests couvrant acces, creation, acompte, validations, log