### PR TITLE
feat(ui): affichage temps reel du montant acompte dans les formulaire…

### DIFF
--- a/frontend/src/features/admin/reservations/ReservationsPage.tsx
+++ b/frontend/src/features/admin/reservations/ReservationsPage.tsx
@@ -17,11 +17,13 @@ import AdminLayout from '../../../layouts/AdminLayout'
 import {
   createReservation,
   deleteReservation,
+  getAcompteSettings,
   getReservation,
   getReservationLookups,
   getReservations,
   updateReservation,
   updateReservationStatus,
+  type AcompteSettings,
 } from './reservations.api'
 import { createPayment } from '../payments/payments.api'
 import type { PaymentMethod } from '../payments/payments.types'
@@ -67,7 +69,7 @@ const legacyStatusLabels: Partial<Record<ReservationStatus, string>> = {
 const allowedTransitions: Record<ReservationStatus, ReservationStatus[]> = {
   en_attente:   ['annulee', 'absence'],
   confirmee:    ['annulee', 'absence'],
-  acompte_paye: ['terminee', 'annulee', 'absence'],
+  acompte_paye: ['en_cours', 'terminee', 'annulee', 'absence'],
   en_cours:     ['terminee', 'annulee', 'absence'],
   terminee:     [],
   annulee:      [],
@@ -225,6 +227,10 @@ function ReservationsPage() {
   const [dateTo, setDateTo] = useState('')
   const [loading, setLoading] = useState(true)
   const [lookupsLoading, setLookupsLoading] = useState(true)
+  const [acompteSettings, setAcompteSettings] = useState<AcompteSettings>({
+    pourcentage_acompte: 0,
+    montant_acompte_defaut: 0,
+  })
   const [saving, setSaving] = useState(false)
   const [detailLoading, setDetailLoading] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
@@ -272,11 +278,14 @@ function ReservationsPage() {
       }
     })
 
-    return {
-      subtotal,
-      duration,
-    }
-  }, [form.details, lookups.coiffures])
+    // Acompte calcule selon les parametres systeme (miroir du calcul serveur)
+    const pct  = acompteSettings.pourcentage_acompte
+    const fixe = acompteSettings.montant_acompte_defaut
+    const raw  = pct > 0 ? Math.round(subtotal * pct / 100) : Math.min(fixe, subtotal)
+    const computedAcompte = Math.min(Math.max(raw, 0), subtotal)
+
+    return { subtotal, duration, computedAcompte }
+  }, [form.details, lookups.coiffures, acompteSettings])
 
   const loadPage = useCallback(async (nextPage: number, nextSearch: string, nextStatus: string, nextCoiffeuse: string, nextFrom: string, nextTo: string) => {
     setLoading(true)
@@ -338,6 +347,10 @@ function ReservationsPage() {
           setLookupsLoading(false)
         }
       })
+
+    getAcompteSettings()
+      .then((s) => { if (!cancelled) setAcompteSettings(s) })
+      .catch(() => {})
 
     return () => {
       cancelled = true
@@ -929,7 +942,12 @@ function ReservationsPage() {
                       ))}
                     </select>
                   </FormField>
-                  <FormField label="Acompte" hint="Vide = calcul automatique">
+                  <FormField
+                    label="Acompte"
+                    hint={preview.subtotal > 0
+                      ? `Vide = auto : ${preview.computedAcompte.toLocaleString('fr-FR')} FCFA${acompteSettings.pourcentage_acompte > 0 ? ` (${acompteSettings.pourcentage_acompte}%)` : ''}`
+                      : 'Vide = calcul automatique'}
+                  >
                     <input className={inputClass} type="number" min="0" step="1" value={form.montant_acompte} onChange={(event) => setForm((current) => ({ ...current, montant_acompte: event.target.value }))} />
                   </FormField>
                 </div>
@@ -955,6 +973,20 @@ function ReservationsPage() {
                       {preview.duration > 0 ? estimatedEnd(form.date_reservation, form.heure_debut, preview.duration) : '-'}
                     </p>
                   </div>
+                  {preview.subtotal > 0 && (
+                    <div className="rounded-lg bg-[#fff2f7] px-3 py-3">
+                      <p className="text-xs font-black uppercase tracking-[0.08em] text-[#c41468]">Acompte attendu</p>
+                      <p className="mt-1 text-xl font-black text-[#c41468]">
+                        {preview.computedAcompte.toLocaleString('fr-FR')} FCFA
+                      </p>
+                      <p className="mt-0.5 text-[10px] font-semibold text-[#c41468]/60">
+                        {acompteSettings.pourcentage_acompte > 0
+                          ? `${acompteSettings.pourcentage_acompte}% du total`
+                          : 'Montant fixe systeme'}
+                        {form.montant_acompte ? ' (champ manuel prioritaire)' : ''}
+                      </p>
+                    </div>
+                  )}
                 </div>
               </section>
             </div>

--- a/frontend/src/features/admin/reservations/reservations.api.ts
+++ b/frontend/src/features/admin/reservations/reservations.api.ts
@@ -113,6 +113,24 @@ export async function deleteReservation(id: number) {
   await apiClient.delete(`/admin/reservations/${id}`)
 }
 
+export type AcompteSettings = {
+  pourcentage_acompte: number
+  montant_acompte_defaut: number
+}
+
+// Recupere les parametres d acompte depuis le catalogue public (cache Redis 5 min).
+// Evite un appel supplementaire vers l API admin et reste coherent avec
+// le calcul serveur qui lit les memes valeurs via SystemSettings.
+export async function getAcompteSettings(): Promise<AcompteSettings> {
+  const response = await apiClient.get<{
+    data: { settings: { pourcentage_acompte: number; montant_acompte_defaut: number } }
+  }>('/client/catalogue')
+  return {
+    pourcentage_acompte: response.data.data.settings.pourcentage_acompte ?? 0,
+    montant_acompte_defaut: response.data.data.settings.montant_acompte_defaut ?? 0,
+  }
+}
+
 export async function getReservationLookups(): Promise<ReservationLookups> {
   const [clients, coiffeuses, coiffures, codesPromo, reglesFidelite] = await Promise.all([
     apiClient.get<ApiCollection<Client>>('/admin/clients', {

--- a/frontend/src/features/gerante/GeranteReservationsPage.tsx
+++ b/frontend/src/features/gerante/GeranteReservationsPage.tsx
@@ -214,6 +214,7 @@ function RaisonModal({ reservation, targetStatus, onConfirm, onCancel, saving }:
 
 type CatVariante = { id: number; nom: string; prix: number; duree_minutes: number }
 type CatCoiffure = { id: number; nom: string; variantes: CatVariante[] }
+type CatSettings = { pourcentage_acompte: number; montant_acompte_defaut: number }
 
 // ── Modal creation reservation physique ───────────────────────────────────
 
@@ -224,6 +225,7 @@ type NouvelleReservationModalProps = {
 
 function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModalProps) {
   const [coiffures, setCoiffures] = useState<CatCoiffure[]>([])
+  const [catSettings, setCatSettings] = useState<CatSettings>({ pourcentage_acompte: 0, montant_acompte_defaut: 0 })
   const [clients, setClients] = useState<Client[]>([])
   const [clientSearch, setClientSearch] = useState('')
   const [loadingClients, setLoadingClients] = useState(false)
@@ -241,11 +243,17 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
   const [errors, setErrors] = useState<Record<string, string[]>>({})
   const clientSearchRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Chargement du catalogue coiffures au montage
+  // Chargement du catalogue (coiffures + parametres acompte) au montage
   useEffect(() => {
     void apiClient
-      .get<{ data: { coiffures: CatCoiffure[] } }>('/client/catalogue')
-      .then((r) => setCoiffures(r.data.data.coiffures))
+      .get<{ data: { coiffures: CatCoiffure[]; settings: CatSettings } }>('/client/catalogue')
+      .then((r) => {
+        setCoiffures(r.data.data.coiffures)
+        setCatSettings({
+          pourcentage_acompte:    r.data.data.settings.pourcentage_acompte    ?? 0,
+          montant_acompte_defaut: r.data.data.settings.montant_acompte_defaut ?? 0,
+        })
+      })
       .catch(() => {})
   }, [])
 
@@ -265,7 +273,18 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
     }, 300)
   }, [clientSearch])
 
-  const selectedCoiffure = coiffures.find((c) => c.id === coiffureId) ?? null
+  const selectedCoiffure  = coiffures.find((c) => c.id === coiffureId) ?? null
+  const selectedVariante  = selectedCoiffure?.variantes.find((v) => v.id === varianteId) ?? null
+
+  // Calcul cote client du montant acompte attendu (miroir du calcul serveur)
+  let acompteEstime: number | null = null
+  if (selectedVariante) {
+    const prix = selectedVariante.prix
+    const pct  = catSettings.pourcentage_acompte
+    const fixe = catSettings.montant_acompte_defaut
+    const raw  = pct > 0 ? Math.round(prix * pct / 100) : Math.min(fixe, prix)
+    acompteEstime = Math.min(Math.max(raw, 0), prix)
+  }
 
   function handleCoiffureChange(id: number) {
     setCoiffureId(id)
@@ -435,6 +454,22 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
 
           {/* Acompte */}
           <div className="rounded-xl border border-gray-100 bg-gray-50 p-3">
+            {/* Montant de l acompte calcule en temps reel des la selection de la variante */}
+            {acompteEstime !== null && acompteEstime > 0 && (
+              <div className="mb-3 rounded-lg bg-[#fff2f7] px-3 py-2">
+                <p className="text-[10px] font-black uppercase tracking-widest text-[#c41468]">
+                  Acompte attendu
+                </p>
+                <p className="mt-0.5 text-lg font-black text-[#c41468]">
+                  {acompteEstime.toLocaleString('fr-FR')} FCFA
+                </p>
+                <p className="text-[10px] text-[#c41468]/60">
+                  {catSettings.pourcentage_acompte > 0
+                    ? `${catSettings.pourcentage_acompte}% du prix de la prestation`
+                    : 'Montant fixe configure'}
+                </p>
+              </div>
+            )}
             <label className="flex cursor-pointer items-center gap-2">
               <input
                 type="checkbox"
@@ -461,9 +496,11 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
                 )}
               </div>
             )}
-            <p className="mt-2 text-[11px] text-gray-400">
-              Le montant est calcule selon le parametre systeme (pourcentage ou montant fixe).
-            </p>
+            {(!acompteEstime || acompteEstime === 0) && (
+              <p className="mt-2 text-[11px] text-gray-400">
+                Selectionnez une coiffure pour voir le montant de l&apos;acompte.
+              </p>
+            )}
           </div>
 
           {/* Boutons */}


### PR DESCRIPTION
…s gerante et admin

- Gerante : carte rose « Acompte attendu » visible des la selection d'une variante
- Admin : hint dynamique sur le champ acompte + carte rose dans la synthese
- Formule identique cote client et serveur : % si configure, sinon montant fixe
- Parametres lus depuis /client/catalogue (cache Redis, coherent avec le calcul serveur)
- Fix allowedTransitions admin : acompte_paye -> en_cours desormais autorise