### PR TITLE
feat(validation): bloquer reservations sur dates/heures passees

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/Admin/ReservationController.php
@@ -369,6 +369,14 @@ class ReservationController extends Controller
         $startsAt = Carbon::createFromFormat('Y-m-d H:i', sprintf('%s %s', $reservationData['date_reservation'], $reservationData['heure_debut']));
         $endsAt = $startsAt->copy()->addMinutes($duration);
 
+        // Pour une nouvelle reservation : bloquer un creneau passe sur le jour courant.
+        // Les dates passees restent autorisees pour la saisie retroactive.
+        if ($reservation === null && $startsAt->isToday() && $startsAt->isPast()) {
+            throw ValidationException::withMessages([
+                'heure_debut' => 'Le creneau selectionne est deja passe.',
+            ]);
+        }
+
         if (! $startsAt->isSameDay($endsAt)) {
             throw ValidationException::withMessages([
                 'heure_debut' => 'La reservation doit se terminer le meme jour.',

--- a/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
@@ -87,7 +87,7 @@ class ReservationController extends Controller
         $data = $request->validate([
             'client_id'                      => ['required', 'integer', 'exists:clients,id'],
             'coiffeuse_id'                   => ['nullable', 'integer', Rule::exists('coiffeuses', 'id')->where('actif', true)],
-            'date_reservation'               => ['required', 'date'],
+            'date_reservation'               => ['required', 'date', 'after_or_equal:today'],
             'heure_debut'                    => ['required', 'date_format:H:i'],
             'details'                        => ['required', 'array', 'min:1'],
             'details.*.coiffure_id'          => ['required', 'integer', 'exists:coiffures,id'],
@@ -130,6 +130,13 @@ class ReservationController extends Controller
 
         $startsAt = Carbon::createFromFormat('Y-m-d H:i', $data['date_reservation'] . ' ' . $data['heure_debut']);
         $endsAt   = $startsAt->copy()->addMinutes($duration);
+
+        // Creneau dans le passe sur le jour courant : interdit meme si la date est valide.
+        if ($startsAt->isPast()) {
+            throw ValidationException::withMessages([
+                'heure_debut' => 'Le creneau selectionne est deja passe.',
+            ]);
+        }
 
         if (! $startsAt->isSameDay($endsAt)) {
             throw ValidationException::withMessages([

--- a/frontend/src/features/admin/reservations/ReservationsPage.tsx
+++ b/frontend/src/features/admin/reservations/ReservationsPage.tsx
@@ -908,7 +908,14 @@ function ReservationsPage() {
                     <input className={inputClass} type="date" value={form.date_reservation} onChange={(event) => setForm((current) => ({ ...current, date_reservation: event.target.value }))} required />
                   </FormField>
                   <FormField label="Heure debut">
-                    <input className={inputClass} type="time" value={form.heure_debut} onChange={(event) => setForm((current) => ({ ...current, heure_debut: event.target.value }))} required />
+                    <input
+                      className={inputClass}
+                      type="time"
+                      value={form.heure_debut}
+                      min={(() => { const n = new Date(); const todayStr = `${n.getFullYear()}-${String(n.getMonth()+1).padStart(2,'0')}-${String(n.getDate()).padStart(2,'0')}`; return !editing && form.date_reservation === todayStr ? `${String(n.getHours()).padStart(2,'0')}:${String(n.getMinutes()).padStart(2,'0')}` : undefined })()}
+                      onChange={(event) => setForm((current) => ({ ...current, heure_debut: event.target.value }))}
+                      required
+                    />
                   </FormField>
                   <FormField label="Statut">
                     <select className={inputClass} value={form.statut} onChange={(event) => setForm((current) => ({ ...current, statut: event.target.value as ReservationStatus }))}>

--- a/frontend/src/features/gerante/GeranteReservationsPage.tsx
+++ b/frontend/src/features/gerante/GeranteReservationsPage.tsx
@@ -420,6 +420,7 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
               <input
                 type="date"
                 value={date}
+                min={(() => { const n = new Date(); return `${n.getFullYear()}-${String(n.getMonth()+1).padStart(2,'0')}-${String(n.getDate()).padStart(2,'0')}` })()}
                 onChange={(e) => setDate(e.target.value)}
                 required
                 className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
@@ -433,6 +434,7 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
               <input
                 type="time"
                 value={heure}
+                min={(() => { const n = new Date(); const todayStr = `${n.getFullYear()}-${String(n.getMonth()+1).padStart(2,'0')}-${String(n.getDate()).padStart(2,'0')}`; return date === todayStr ? `${String(n.getHours()).padStart(2,'0')}:${String(n.getMinutes()).padStart(2,'0')}` : undefined })()}
                 onChange={(e) => setHeure(e.target.value)}
                 required
                 className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"


### PR DESCRIPTION
- Gerante : date_reservation >= aujourd'hui (after_or_equal:today)
  + heure refusee si le creneau est deja passe (isPast())
- Admin : dates passees autorisees (saisie retroactive)
  + heure passee bloquee uniquement si date = aujourd'hui et nouvelle resa
- Frontend gerante : min=today sur le date input, min=heure courante si date=today
- Frontend admin : min=heure courante sur le time input si date=today et creation