### PR TITLE
feat: paiement obligatoire a la creation gerante + vue paiements + fi…

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/DashboardController.php
+++ b/backend/app/Http/Controllers/Api/Admin/DashboardController.php
@@ -104,22 +104,16 @@ class DashboardController extends Controller
             ];
         }
 
+        // Les remboursements (type=remboursement, statut=valide) sont deduits
+        // du CA pour reflechir l argent reellement encaisse apres retours.
+        $caToday    = $this->netCA(now()->toDateString());
+        $caYesterday = $this->netCA(now()->subDay()->toDateString());
+
         return [
             'available' => true,
-            'value' => $today = (float) DB::table('paiements')
-                ->whereDate('date_paiement', now()->toDateString())
-                ->where('statut', 'valide')
-                ->whereIn('type', ['acompte', 'solde', 'complet', 'ajustement'])
-                ->sum('montant'),
-            'trend' => $this->trendLabel(
-                $today,
-                (float) DB::table('paiements')
-                    ->whereDate('date_paiement', now()->subDay()->toDateString())
-                    ->where('statut', 'valide')
-                    ->whereIn('type', ['acompte', 'solde', 'complet', 'ajustement'])
-                    ->sum('montant')
-            ),
-            'currency' => 'FCFA',
+            'value'     => $caToday,
+            'trend'     => $this->trendLabel($caToday, $caYesterday),
+            'currency'  => 'FCFA',
         ];
     }
 
@@ -454,6 +448,23 @@ class DashboardController extends Controller
     /**
      * @return array<string, mixed>
      */
+    private function netCA(string $date): float
+    {
+        $entrees = (float) DB::table('paiements')
+            ->whereDate('date_paiement', $date)
+            ->where('statut', 'valide')
+            ->whereIn('type', ['acompte', 'solde', 'complet', 'ajustement'])
+            ->sum('montant');
+
+        $remboursements = (float) DB::table('paiements')
+            ->whereDate('date_paiement', $date)
+            ->where('statut', 'valide')
+            ->where('type', 'remboursement')
+            ->sum('montant');
+
+        return max(0, $entrees - $remboursements);
+    }
+
     private function depensesRecentes(): array
     {
         if (! $this->hasTable('depenses')) {

--- a/backend/app/Http/Controllers/Api/Admin/PaiementController.php
+++ b/backend/app/Http/Controllers/Api/Admin/PaiementController.php
@@ -11,6 +11,7 @@ use App\Models\Paiement;
 use App\Models\ParametreSysteme;
 use App\Models\Reservation;
 use App\Services\ClientResolver;
+use App\Services\SystemLogger;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -28,7 +29,10 @@ class PaiementController extends Controller
     private const METHODS = ['especes', 'wave', 'orange_money', 'carte_bancaire', 'virement', 'autre'];
     private const STATUSES = ['en_attente', 'valide', 'annule', 'rembourse'];
 
-    public function __construct(private readonly ClientResolver $clientResolver) {}
+    public function __construct(
+        private readonly ClientResolver $clientResolver,
+        private readonly SystemLogger   $logger,
+    ) {}
 
     public function index(Request $request): JsonResponse
     {
@@ -51,9 +55,16 @@ class PaiementController extends Controller
         $data = $this->validatedPaymentData($request);
 
         $paiement = DB::transaction(fn (): Paiement => $this->persistPayment($data));
-        // Notif recue en queue (I6) : la requete admin repond sans attendre
-        // Twilio/WhatsApp/Mail.
         SendPaymentReceiptNotifications::dispatch($paiement->id);
+
+        $this->logger->record(
+            action: 'admin_paiement_creation',
+            module: 'paiements',
+            description: "Paiement #{$paiement->id} cree ({$paiement->type}, {$paiement->montant} {$paiement->devise})",
+            subject: $paiement,
+            after: ['type' => $paiement->type, 'montant' => $paiement->montant, 'statut' => $paiement->statut, 'mode' => $paiement->mode_paiement],
+            request: $request,
+        );
 
         return response()->json([
             'message' => 'Paiement enregistre.',
@@ -74,11 +85,21 @@ class PaiementController extends Controller
 
     public function update(Request $request, Paiement $paiement): JsonResponse
     {
-        $data = $this->validatedPaymentData($request, $paiement);
+        $before = ['type' => $paiement->type, 'montant' => $paiement->montant, 'statut' => $paiement->statut];
+        $data   = $this->validatedPaymentData($request, $paiement);
 
         $paiement = DB::transaction(fn (): Paiement => $this->persistPayment($data, $paiement));
-        // Notif recue en queue (I6).
         SendPaymentReceiptNotifications::dispatch($paiement->id);
+
+        $this->logger->record(
+            action: 'admin_paiement_modification',
+            module: 'paiements',
+            description: "Paiement #{$paiement->id} modifie",
+            subject: $paiement,
+            before: $before,
+            after: ['type' => $paiement->type, 'montant' => $paiement->montant, 'statut' => $paiement->statut, 'mode' => $paiement->mode_paiement],
+            request: $request,
+        );
 
         return response()->json([
             'message' => 'Paiement mis a jour.',
@@ -89,10 +110,10 @@ class PaiementController extends Controller
 
     public function cancel(Request $request, Paiement $paiement): JsonResponse
     {
-        $data = $request->validate([
+        $data  = $request->validate([
             'notes' => ['nullable', 'string', 'max:5000'],
         ]);
-
+        $before        = ['type' => $paiement->type, 'montant' => $paiement->montant, 'statut' => $paiement->statut];
         $reservationId = $paiement->reservation_id;
 
         DB::transaction(function () use ($paiement, $data, $reservationId): void {
@@ -104,6 +125,16 @@ class PaiementController extends Controller
             ])->save();
             $this->syncReservationPaymentState($reservationId);
         });
+
+        $this->logger->record(
+            action: 'admin_paiement_annulation',
+            module: 'paiements',
+            description: "Paiement #{$paiement->id} annule ({$paiement->type}, {$paiement->montant} {$paiement->devise})",
+            subject: $paiement,
+            before: $before,
+            after:  ['statut' => 'annule'],
+            request: $request,
+        );
 
         return response()->json([
             'message' => 'Paiement annule.',
@@ -131,7 +162,7 @@ class PaiementController extends Controller
         ]);
     }
 
-    public function destroy(Paiement $paiement): JsonResponse
+    public function destroy(Request $request, Paiement $paiement): JsonResponse
     {
         // Un paiement valide est une trace comptable : utiliser l annulation plutot.
         if ($paiement->statut === 'valide') {
@@ -140,6 +171,7 @@ class PaiementController extends Controller
             ]);
         }
 
+        $snapshot      = ['type' => $paiement->type, 'montant' => $paiement->montant, 'statut' => $paiement->statut];
         $reservationId = $paiement->reservation_id;
 
         DB::transaction(function () use ($paiement, $reservationId): void {
@@ -148,6 +180,15 @@ class PaiementController extends Controller
             $paiement->delete();
             $this->syncReservationPaymentState($reservationId);
         });
+
+        $this->logger->record(
+            action: 'admin_paiement_suppression',
+            module: 'paiements',
+            description: "Paiement #{$paiement->id} supprime ({$paiement->type}, {$paiement->montant} {$paiement->devise})",
+            subject: null,
+            before: $snapshot,
+            request: $request,
+        );
 
         return response()->json(['message' => 'Paiement supprime.']);
     }

--- a/backend/app/Http/Controllers/Api/Admin/RapportStatistiqueController.php
+++ b/backend/app/Http/Controllers/Api/Admin/RapportStatistiqueController.php
@@ -161,11 +161,20 @@ class RapportStatistiqueController extends Controller
             return 0.0;
         }
 
-        return (float) DB::table('paiements')
+        $entrees = (float) DB::table('paiements')
             ->whereBetween('date_paiement', [$start, $end])
             ->where('statut', 'valide')
             ->whereIn('type', ['acompte', 'solde', 'complet', 'ajustement'])
             ->sum('montant');
+
+        // Les remboursements reduisent le CA net de la periode.
+        $remboursements = (float) DB::table('paiements')
+            ->whereBetween('date_paiement', [$start, $end])
+            ->where('statut', 'valide')
+            ->where('type', 'remboursement')
+            ->sum('montant');
+
+        return max(0, $entrees - $remboursements);
     }
 
     private function depenses(CarbonImmutable $start, CarbonImmutable $end): float

--- a/backend/app/Http/Controllers/Api/Gerante/PaiementController.php
+++ b/backend/app/Http/Controllers/Api/Gerante/PaiementController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\Api\Gerante;
+
+use App\Http\Controllers\Controller;
+use App\Models\Paiement;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PaiementController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = max(1, min($request->integer('per_page', 15), 100));
+
+        $paiements = $this->filteredQuery($request)
+            ->with($this->relations())
+            ->latest('date_paiement')
+            ->latest('id')
+            ->paginate($perPage);
+
+        return response()->json([
+            'data' => $paiements,
+        ]);
+    }
+
+    public function show(Paiement $paiement): JsonResponse
+    {
+        $paiement->load($this->relations());
+
+        return response()->json([
+            'data' => $paiement,
+        ]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function relations(): array
+    {
+        return [
+            'client',
+            'reservation.client',
+            'reservation.details',
+        ];
+    }
+
+    private function filteredQuery(Request $request): Builder
+    {
+        return Paiement::query()
+            ->when($request->filled('statut'), fn (Builder $q) => $q->where('statut', $request->string('statut')->toString()))
+            ->when($request->filled('type'), fn (Builder $q) => $q->where('type', $request->string('type')->toString()))
+            ->when($request->filled('mode_paiement'), fn (Builder $q) => $q->where('mode_paiement', $request->string('mode_paiement')->toString()))
+            ->when($request->integer('reservation_id'), fn (Builder $q, int $id) => $q->where('reservation_id', $id))
+            ->when($request->filled('date_from'), fn (Builder $q) => $q->whereDate('date_paiement', '>=', $request->date('date_from')))
+            ->when($request->filled('date_to'), fn (Builder $q) => $q->whereDate('date_paiement', '<=', $request->date('date_to')))
+            ->when($request->filled('search'), function (Builder $q) use ($request): void {
+                $search = trim($request->string('search')->toString());
+                $q->where(function (Builder $sub) use ($search): void {
+                    $sub->where('numero_recu', 'ilike', "%{$search}%")
+                        ->orWhereHas('client', fn (Builder $c) => $c
+                            ->where('nom', 'ilike', "%{$search}%")
+                            ->orWhere('prenom', 'ilike', "%{$search}%")
+                            ->orWhere('telephone', 'ilike', "%{$search}%"))
+                        ->orWhereHas('reservation.client', fn (Builder $c) => $c
+                            ->where('nom', 'ilike', "%{$search}%")
+                            ->orWhere('prenom', 'ilike', "%{$search}%"));
+                    if (ctype_digit($search)) {
+                        $sub->orWhere('id', (int) $search)
+                            ->orWhere('reservation_id', (int) $search);
+                    }
+                });
+            });
+    }
+}

--- a/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Gerante;
 
 use App\Http\Controllers\Controller;
+use App\Jobs\SendPaymentReceiptNotifications;
 use App\Models\Client;
 use App\Models\Coiffure;
 use App\Models\Paiement;
@@ -82,7 +83,7 @@ class ReservationController extends Controller
 
     public function store(Request $request): JsonResponse
     {
-        $enregistrerAcompte = $request->boolean('enregistrer_acompte', false);
+        $typePaiement = $request->input('type_paiement'); // 'acompte' | 'soldee'
 
         $data = $request->validate([
             'client_id'                      => ['required', 'integer', 'exists:clients,id'],
@@ -94,12 +95,9 @@ class ReservationController extends Controller
             'details.*.variante_coiffure_id' => ['required', 'integer', 'exists:variantes_coiffures,id'],
             'details.*.quantite'             => ['sometimes', 'integer', 'min:1', 'max:10'],
             'notes'                          => ['nullable', 'string', 'max:5000'],
-            'enregistrer_acompte'            => ['sometimes', 'boolean'],
-            'mode_paiement_acompte'          => [
-                $enregistrerAcompte ? 'required' : 'sometimes',
-                'nullable',
-                Rule::in(['especes', 'wave', 'orange_money', 'carte_bancaire', 'autre']),
-            ],
+            // La gerante doit toujours encaisser un paiement a la creation.
+            'type_paiement'  => ['required', Rule::in(['acompte', 'soldee'])],
+            'mode_paiement'  => ['required', Rule::in(['especes', 'wave', 'orange_money', 'carte_bancaire', 'autre'])],
         ]);
 
         $client = Client::query()->find($data['client_id']);
@@ -148,7 +146,7 @@ class ReservationController extends Controller
         $this->ensureWithinBusinessHours($startsAt, $endsAt);
         $this->ensureSalonCapacity($data, null);
 
-        // Acompte cible calcule par les parametres systeme
+        // Montant d acompte calcule par les parametres systeme (utile uniquement si type=acompte)
         $depositPercent  = (float) $this->settingValue('pourcentage_acompte', 0);
         $depositFallback = (float) $this->settingValue('montant_acompte_defaut', 0);
         $deposit         = $depositPercent > 0
@@ -156,12 +154,18 @@ class ReservationController extends Controller
             : min($depositFallback, $subtotal);
         $deposit = min(max($deposit, 0), $subtotal);
 
-        $reservation = DB::transaction(function () use ($data, $details, $subtotal, $duration, $deposit, $endsAt): Reservation {
-            // La source est toujours physique : la gerante gere uniquement
-            // les clientes qui se presentent en personne au salon.
-            $statut = ($data['enregistrer_acompte'] ?? false) && $deposit > 0
-                ? 'acompte_paye'
-                : 'en_attente';
+        $isSoldee = $data['type_paiement'] === 'soldee';
+
+        [$reservation, $paiement] = DB::transaction(function () use ($data, $details, $subtotal, $duration, $deposit, $endsAt, $isSoldee): array {
+            // Soldee : la cliente paie tout maintenant, service en cours.
+            // Acompte : elle verse un depot, reste a payer plus tard.
+            $statut         = $isSoldee ? 'en_cours'     : 'acompte_paye';
+            $montantPaiement = $isSoldee ? $subtotal      : $deposit;
+            $montantRestant  = $isSoldee ? 0.0            : round(max($subtotal - $deposit, 0), 2);
+            $typePaiem       = $isSoldee ? 'complet'      : 'acompte';
+            $notesPaiem      = $isSoldee
+                ? 'Paiement complet encaisse par la gerante a la creation (soldee).'
+                : 'Acompte encaisse par la gerante a la creation de la reservation.';
 
             $res = Reservation::query()->create([
                 'client_id'            => $data['client_id'],
@@ -174,8 +178,8 @@ class ReservationController extends Controller
                 'source'               => 'physique',
                 'montant_total'        => round($subtotal, 2),
                 'montant_reduction'    => 0,
-                'montant_acompte'      => round($deposit, 2),
-                'montant_restant'      => round(max($subtotal - $deposit, 0), 2),
+                'montant_acompte'      => round($montantPaiement, 2),
+                'montant_restant'      => $montantRestant,
                 'devise'               => 'FCFA',
                 'fidelite_appliquee'   => false,
                 'notes'                => $data['notes'] ?? null,
@@ -185,28 +189,29 @@ class ReservationController extends Controller
                 $res->details()->create($detail);
             }
 
-            if ($statut === 'acompte_paye') {
-                // UUID temporaire obligatoire car numero_recu est NOT NULL + UNIQUE.
-                // On le remplace par le numero definitif apres avoir obtenu l id.
-                $paiement = Paiement::query()->create([
-                    'reservation_id' => $res->id,
-                    'client_id'      => $res->client_id,
-                    'numero_recu'    => 'TEMP-' . Str::uuid()->toString(),
-                    'type'           => 'acompte',
-                    'mode_paiement'  => $data['mode_paiement_acompte'],
-                    'montant'        => $res->montant_acompte,
-                    'devise'         => 'FCFA',
-                    'statut'         => 'valide',
-                    'date_paiement'  => now(),
-                    'notes'          => 'Acompte encaisse par la gerante a la creation de la reservation.',
-                ]);
-                $paiement->update([
-                    'numero_recu' => 'BT-' . now()->format('Ymd') . '-' . str_pad((string) $paiement->id, 4, '0', STR_PAD_LEFT),
-                ]);
-            }
+            // UUID temporaire obligatoire car numero_recu est NOT NULL + UNIQUE.
+            // On le remplace par le numero definitif apres avoir obtenu l id.
+            $paiem = Paiement::query()->create([
+                'reservation_id' => $res->id,
+                'client_id'      => $res->client_id,
+                'numero_recu'    => 'TEMP-' . Str::uuid()->toString(),
+                'type'           => $typePaiem,
+                'mode_paiement'  => $data['mode_paiement'],
+                'montant'        => round($montantPaiement, 2),
+                'devise'         => 'FCFA',
+                'statut'         => 'valide',
+                'date_paiement'  => now(),
+                'notes'          => $notesPaiem,
+            ]);
+            $paiem->update([
+                'numero_recu' => 'BT-' . now()->format('Ymd') . '-' . str_pad((string) $paiem->id, 4, '0', STR_PAD_LEFT),
+            ]);
 
-            return $res;
+            return [$res, $paiem];
         });
+
+        // Notif cliente (WhatsApp + email) en queue, sans bloquer la reponse.
+        SendPaymentReceiptNotifications::dispatch($paiement->id);
 
         $this->logger->record(
             action: 'gerante_creation_reservation',
@@ -214,15 +219,16 @@ class ReservationController extends Controller
             description: "Reservation #{$reservation->id} creee en physique pour la cliente #{$reservation->client_id}",
             subject: $reservation,
             after: [
-                'statut'        => $reservation->statut,
-                'montant_total' => $reservation->montant_total,
-                'source'        => 'physique',
+                'statut'         => $reservation->statut,
+                'montant_total'  => $reservation->montant_total,
+                'type_paiement'  => $data['type_paiement'],
+                'source'         => 'physique',
             ],
             metadata: array_filter([
-                'reservation_id'   => $reservation->id,
-                'client_id'        => $reservation->client_id,
-                'acompte_encaisse' => ($data['enregistrer_acompte'] ?? false) && $reservation->statut === 'acompte_paye',
-                'actor_role'       => 'gerante',
+                'reservation_id' => $reservation->id,
+                'client_id'      => $reservation->client_id,
+                'type_paiement'  => $data['type_paiement'],
+                'actor_role'     => 'gerante',
             ]),
             request: $request,
         );
@@ -270,7 +276,9 @@ class ReservationController extends Controller
         $oldStatus = $reservation->statut;
         $newStatus = $data['statut'];
 
-        DB::transaction(function () use ($data, $reservation, $newStatus, $hasSolde): void {
+        $soldePaiementId = null;
+
+        DB::transaction(function () use ($data, $reservation, $newStatus, $hasSolde, &$soldePaiementId): void {
             if ($hasSolde && ($data['enregistrer_paiement'] ?? false)) {
                 // UUID temporaire obligatoire car numero_recu est NOT NULL + UNIQUE.
                 // On le remplace par le numero definitif apres avoir obtenu l id.
@@ -290,12 +298,18 @@ class ReservationController extends Controller
                     'numero_recu' => 'BT-' . now()->format('Ymd') . '-' . str_pad((string) $paiement->id, 4, '0', STR_PAD_LEFT),
                 ]);
                 $reservation->montant_restant = 0;
+                $soldePaiementId = $paiement->id;
             }
 
             $reservation->statut = $newStatus;
             $this->applyStatusTimestamps($reservation);
             $reservation->save();
         });
+
+        // Notif solde paye : envoye en queue apres la transaction pour ne pas bloquer.
+        if ($soldePaiementId !== null) {
+            SendPaymentReceiptNotifications::dispatch($soldePaiementId);
+        }
 
         $this->logStatusChange($request, $reservation, $oldStatus, $newStatus, $data['raison'] ?? null, $isSensitive);
 

--- a/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/Gerante/ReservationController.php
@@ -33,11 +33,13 @@ class ReservationController extends Controller
         'absence'      => [],
     ];
 
-    // Transitions sensibles : un acompte a deja ete encaisse. La raison est
+    // Transitions sensibles : un paiement a deja ete encaisse. La raison est
     // obligatoire (min 20 car.) pour tracer toute annulation post-paiement
     // et decourager les detournements de caisse.
+    // en_cours couvre aussi le cas "soldee" : paiement complet encaisse a la creation.
     private const SENSITIVE_TRANSITIONS = [
         'acompte_paye' => ['annulee', 'absence'],
+        'en_cours'     => ['annulee', 'absence'],
     ];
 
     private const BLOCKING_STATUSES = [
@@ -155,6 +157,14 @@ class ReservationController extends Controller
         $deposit = min(max($deposit, 0), $subtotal);
 
         $isSoldee = $data['type_paiement'] === 'soldee';
+
+        // Si la gerante choisit acompte mais qu aucun montant n est configure,
+        // on refuse : mieux vaut un message clair que creer un paiement a 0 FCFA.
+        if (! $isSoldee && $deposit <= 0) {
+            throw ValidationException::withMessages([
+                'type_paiement' => 'Aucun acompte configure dans le systeme. Choisissez "Soldee" pour un paiement complet.',
+            ]);
+        }
 
         [$reservation, $paiement] = DB::transaction(function () use ($data, $details, $subtotal, $duration, $deposit, $endsAt, $isSoldee): array {
             // Soldee : la cliente paie tout maintenant, service en cours.

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Api\Admin\EvenementAnalyticsController;
 use App\Http\Controllers\Api\Admin\GeranteController;
 use App\Http\Controllers\Api\Admin\ImageCoiffureController;
 use App\Http\Controllers\Api\Gerante\ClientController as GeranteClientController;
+use App\Http\Controllers\Api\Gerante\PaiementController as GerantePaiementController;
 use App\Http\Controllers\Api\Gerante\ReservationController as GeranteReservationController;
 use App\Http\Controllers\Api\Admin\ListeNoireClientController;
 use App\Http\Controllers\Api\Admin\LogSystemeController;
@@ -167,4 +168,6 @@ Route::middleware(['auth.token', 'role:gerante', 'log.admin'])
         Route::post('clients', [GeranteClientController::class, 'store'])->name('clients.store');
         Route::get('clients/{client}', [GeranteClientController::class, 'show'])->name('clients.show');
         Route::put('clients/{client}', [GeranteClientController::class, 'update'])->name('clients.update');
+        Route::get('paiements', [GerantePaiementController::class, 'index'])->name('paiements.index');
+        Route::get('paiements/{paiement}', [GerantePaiementController::class, 'show'])->name('paiements.show');
     });

--- a/backend/tests/Feature/Gerante/ReservationCreateTest.php
+++ b/backend/tests/Feature/Gerante/ReservationCreateTest.php
@@ -12,19 +12,20 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 /**
- * Tests d integration sur POST /api/gerante/reservations et sur
- * la correction de la transition admin acompte_paye -> en_cours.
+ * Tests d integration sur POST /api/gerante/reservations.
  *
  * Couvre :
  * - acces sans token refuse en 401
  * - acces admin refuse en 403
- * - creation d une reservation physique simple
- * - creation avec acompte : paiement cree + statut acompte_paye
- * - acompte ignore si montant calcule est 0
+ * - creation avec acompte : paiement type=acompte, statut=acompte_paye
+ * - creation soldee : paiement type=complet, statut=en_cours
+ * - acompte refuse si montant calcule est 0 (validation 422)
+ * - mode_paiement requis (champ obligatoire dans les deux cas)
  * - client blackliste refuse en 422
- * - coiffure inactive refuse
+ * - coiffure inactive refuse en 422
  * - log cree a la creation
- * - admin peut maintenant passer acompte_paye en en_cours (fix)
+ * - admin peut passer acompte_paye en en_cours
+ * - gerante doit fournir raison pour annuler une resa en_cours (soldee)
  */
 class ReservationCreateTest extends TestCase
 {
@@ -50,6 +51,9 @@ class ReservationCreateTest extends TestCase
     }
 
     /**
+     * Payload minimal valide. type_paiement et mode_paiement sont desormais
+     * obligatoires : la gerante doit toujours encaisser a la creation.
+     *
      * @return array<string, mixed>
      */
     private function payload(int $clientId, int $coiffureId, int $varianteId): array
@@ -58,6 +62,8 @@ class ReservationCreateTest extends TestCase
             'client_id'        => $clientId,
             'date_reservation' => now()->addDay()->toDateString(),
             'heure_debut'      => '10:00',
+            'type_paiement'    => 'acompte',
+            'mode_paiement'    => 'especes',
             'details'          => [[
                 'coiffure_id'          => $coiffureId,
                 'variante_coiffure_id' => $varianteId,
@@ -83,54 +89,26 @@ class ReservationCreateTest extends TestCase
             ->assertStatus(403);
     }
 
-    // ─── Creation simple ─────────────────────────────────────────────────────
+    // ─── Creation avec acompte ────────────────────────────────────────────────
 
-    public function test_gerante_peut_creer_reservation_physique(): void
+    public function test_creation_acompte_cree_paiement_et_passe_en_acompte_paye(): void
     {
-        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante();
+        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante([], ['prix' => 20000]);
         $client = Client::factory()->create();
         $auth   = $this->loggedInGerante();
+
+        ParametreSysteme::query()->updateOrCreate(
+            ['cle' => 'pourcentage_acompte'],
+            ['valeur' => ['value' => 40], 'type' => 'integer'],
+        );
 
         $response = $this->authenticatedAs($auth)
             ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
             ->postJson('/api/gerante/reservations', $this->payload($client->id, $coiffure->id, $variante->id))
             ->assertStatus(201);
 
-        $response->assertJsonPath('data.statut', 'en_attente');
-        $response->assertJsonPath('data.source', 'physique');
-        $response->assertJsonPath('data.client_id', $client->id);
-
-        $this->assertDatabaseHas('reservations', [
-            'client_id' => $client->id,
-            'source'    => 'physique',
-            'statut'    => 'en_attente',
-        ]);
-    }
-
-    // ─── Creation avec acompte ────────────────────────────────────────────────
-
-    public function test_creation_avec_acompte_cree_paiement_et_passe_en_acompte_paye(): void
-    {
-        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante([], ['prix' => 20000]);
-        $client = Client::factory()->create();
-        $auth   = $this->loggedInGerante();
-
-        // Parametrage : 40 % d acompte (la migration cree deja cette cle — updateOrCreate)
-        ParametreSysteme::query()->updateOrCreate(
-            ['cle' => 'pourcentage_acompte'],
-            ['valeur' => ['value' => 40], 'type' => 'integer'],
-        );
-
-        $payload = $this->payload($client->id, $coiffure->id, $variante->id);
-        $payload['enregistrer_acompte']   = true;
-        $payload['mode_paiement_acompte'] = 'especes';
-
-        $response = $this->authenticatedAs($auth)
-            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
-            ->postJson('/api/gerante/reservations', $payload)
-            ->assertStatus(201);
-
         $response->assertJsonPath('data.statut', 'acompte_paye');
+        $response->assertJsonPath('data.source', 'physique');
 
         $reservationId = $response->json('data.id');
 
@@ -142,15 +120,49 @@ class ReservationCreateTest extends TestCase
             'montant'        => 8000, // 40 % de 20 000
         ]);
 
-        // numero_recu doit avoir ete remplace par le format BT-
         $paiement = Paiement::where('reservation_id', $reservationId)->first();
         $this->assertStringStartsWith('BT-', $paiement->numero_recu);
     }
 
-    public function test_acompte_ignore_si_montant_calcule_est_zero(): void
+    // ─── Creation soldee ─────────────────────────────────────────────────────
+
+    public function test_creation_soldee_cree_paiement_complet_et_passe_en_cours(): void
     {
-        // La migration cree des valeurs par defaut non nulles — on les force a 0
-        // pour tester le cas ou aucun acompte n est configure.
+        ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante([], ['prix' => 25000]);
+        $client = Client::factory()->create();
+        $auth   = $this->loggedInGerante();
+
+        $payload                 = $this->payload($client->id, $coiffure->id, $variante->id);
+        $payload['type_paiement'] = 'soldee';
+        $payload['mode_paiement'] = 'wave';
+
+        $response = $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->postJson('/api/gerante/reservations', $payload)
+            ->assertStatus(201);
+
+        $response->assertJsonPath('data.statut', 'en_cours');
+
+        $reservationId = $response->json('data.id');
+
+        $this->assertDatabaseHas('paiements', [
+            'reservation_id' => $reservationId,
+            'type'           => 'complet',
+            'statut'         => 'valide',
+            'mode_paiement'  => 'wave',
+            'montant'        => 25000,
+        ]);
+
+        $this->assertDatabaseHas('reservations', [
+            'id'              => $reservationId,
+            'montant_restant' => 0,
+        ]);
+    }
+
+    // ─── Validations ─────────────────────────────────────────────────────────
+
+    public function test_acompte_refuse_si_montant_calcule_est_zero(): void
+    {
         ParametreSysteme::query()->updateOrCreate(
             ['cle' => 'pourcentage_acompte'],
             ['valeur' => ['value' => 0]],
@@ -164,43 +176,29 @@ class ReservationCreateTest extends TestCase
         $client = Client::factory()->create();
         $auth   = $this->loggedInGerante();
 
-        $payload = $this->payload($client->id, $coiffure->id, $variante->id);
-        $payload['enregistrer_acompte']   = true;
-        $payload['mode_paiement_acompte'] = 'wave';
-
-        $response = $this->authenticatedAs($auth)
+        // type_paiement=acompte avec deposit=0 doit etre refuse clairement
+        $this->authenticatedAs($auth)
             ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
-            ->postJson('/api/gerante/reservations', $payload)
-            ->assertStatus(201);
-
-        // Acompte calcule a 0 -> statut reste en_attente, aucun paiement cree
-        $response->assertJsonPath('data.statut', 'en_attente');
-        $this->assertDatabaseCount('paiements', 0);
+            ->postJson('/api/gerante/reservations', $this->payload($client->id, $coiffure->id, $variante->id))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['type_paiement']);
     }
 
-    public function test_mode_paiement_acompte_requis_si_enregistrer_acompte(): void
+    public function test_mode_paiement_requis(): void
     {
         ['coiffure' => $coiffure, 'variante' => $variante] = $this->coiffureAvecVariante();
         $client = Client::factory()->create();
         $auth   = $this->loggedInGerante();
 
-        ParametreSysteme::query()->updateOrCreate(
-            ['cle' => 'pourcentage_acompte'],
-            ['valeur' => ['value' => 40], 'type' => 'integer'],
-        );
-
         $payload = $this->payload($client->id, $coiffure->id, $variante->id);
-        $payload['enregistrer_acompte'] = true;
-        // mode_paiement_acompte volontairement absent
+        unset($payload['mode_paiement']);
 
         $this->authenticatedAs($auth)
             ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
             ->postJson('/api/gerante/reservations', $payload)
             ->assertStatus(422)
-            ->assertJsonValidationErrors(['mode_paiement_acompte']);
+            ->assertJsonValidationErrors(['mode_paiement']);
     }
-
-    // ─── Validations ─────────────────────────────────────────────────────────
 
     public function test_client_blackliste_refuse_422(): void
     {
@@ -228,7 +226,7 @@ class ReservationCreateTest extends TestCase
             ->assertStatus(422);
     }
 
-    // ─── Logs ─────────────────────────────────────────────────────────────────
+    // ─── Logs ────────────────────────────────────────────────────────────────
 
     public function test_creation_cree_log_systeme(): void
     {
@@ -247,7 +245,7 @@ class ReservationCreateTest extends TestCase
         ]);
     }
 
-    // ─── Fix transition admin : acompte_paye → en_cours ─────────────────────
+    // ─── Transitions sensibles ────────────────────────────────────────────────
 
     public function test_admin_peut_passer_acompte_paye_en_en_cours(): void
     {
@@ -261,5 +259,30 @@ class ReservationCreateTest extends TestCase
             ])
             ->assertOk()
             ->assertJsonPath('data.statut', 'en_cours');
+    }
+
+    public function test_gerante_doit_fournir_raison_pour_annuler_resa_en_cours(): void
+    {
+        $reservation = Reservation::factory()->create(['statut' => 'en_cours']);
+        $auth        = $this->loggedInGerante();
+
+        // Sans raison : refuse
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'annulee',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['raison']);
+
+        // Avec raison suffisamment longue : accepte
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'annulee',
+                'raison' => 'Cliente ne sest pas presentee apres paiement complet.',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.statut', 'annulee');
     }
 }

--- a/backend/tests/Feature/Gerante/ReservationStatusTest.php
+++ b/backend/tests/Feature/Gerante/ReservationStatusTest.php
@@ -72,10 +72,21 @@ class ReservationStatusTest extends TestCase
         $auth        = $this->loggedInGerante();
         $reservation = Reservation::factory()->create(['statut' => 'en_cours']);
 
+        // Sans raison : refuse (en_cours est dans SENSITIVE_TRANSITIONS comme acompte_paye)
         $this->authenticatedAs($auth)
             ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
             ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
                 'statut' => 'annulee',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['raison']);
+
+        // Avec raison suffisamment longue : accepte
+        $this->authenticatedAs($auth)
+            ->withHeader('X-XSRF-TOKEN', $auth['csrf'])
+            ->patchJson("/api/gerante/reservations/{$reservation->id}/statut", [
+                'statut' => 'annulee',
+                'raison' => 'Cliente ne sest pas presentee apres paiement complet.',
             ])
             ->assertOk()
             ->assertJsonPath('data.statut', 'annulee');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ const PromotionsPage = lazy(() => import('./features/admin/promotions/Promotions
 const LogsPage = lazy(() => import('./features/admin/logs-systeme/LogsPage'))
 const GeranteReservationsPage = lazy(() => import('./features/gerante/GeranteReservationsPage'))
 const GeranteClientsPage = lazy(() => import('./features/gerante/GeranteClientsPage'))
+const GerantePaiementsPage = lazy(() => import('./features/gerante/GerantePaiementsPage'))
 
 function NotFound() {
   return (
@@ -117,6 +118,16 @@ function App() {
           <RequireAuth role="gerante">
             <Suspense fallback={<RouteSuspenseFallback />}>
               <GeranteClientsPage />
+            </Suspense>
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/manager/paiements"
+        element={
+          <RequireAuth role="gerante">
+            <Suspense fallback={<RouteSuspenseFallback />}>
+              <GerantePaiementsPage />
             </Suspense>
           </RequireAuth>
         }

--- a/frontend/src/features/gerante/GerantePaiementsPage.tsx
+++ b/frontend/src/features/gerante/GerantePaiementsPage.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiClient } from '../../lib/apiClient'
+import GeranteLayout from '../../layouts/GeranteLayout'
+import type { LaravelPaginated, Paiement, PaymentType, PaymentStatus } from '../admin/payments/payments.types'
+
+type QueryParams = {
+  page?: number
+  per_page?: number
+  search?: string
+  statut?: string
+  type?: string
+  date_from?: string
+  date_to?: string
+}
+
+async function getGerantePaiements(params: QueryParams = {}): Promise<LaravelPaginated<Paiement>> {
+  const response = await apiClient.get<{ data: LaravelPaginated<Paiement> }>('/gerante/paiements', { params })
+  return response.data.data
+}
+
+const TYPE_LABELS: Record<PaymentType, string> = {
+  acompte:      'Acompte',
+  solde:        'Solde',
+  complet:      'Complet',
+  remboursement:'Remboursement',
+  ajustement:   'Ajustement',
+}
+
+const STATUS_LABELS: Record<PaymentStatus, string> = {
+  en_attente: 'En attente',
+  valide:     'Validé',
+  annule:     'Annulé',
+  rembourse:  'Remboursé',
+}
+
+const TYPE_COLORS: Record<PaymentType, string> = {
+  acompte:       'bg-blue-50 text-blue-700',
+  solde:         'bg-green-50 text-green-700',
+  complet:       'bg-emerald-50 text-emerald-700',
+  remboursement: 'bg-red-50 text-red-700',
+  ajustement:    'bg-amber-50 text-amber-700',
+}
+
+const STATUS_COLORS: Record<PaymentStatus, string> = {
+  en_attente: 'bg-yellow-50 text-yellow-700',
+  valide:     'bg-green-50 text-green-700',
+  annule:     'bg-red-50 text-red-700',
+  rembourse:  'bg-purple-50 text-purple-700',
+}
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+function formatAmount(v: number | string) {
+  return Number(v).toLocaleString('fr-FR')
+}
+
+export default function GerantePaiementsPage() {
+  const today = new Date().toISOString().slice(0, 10)
+  const [items, setItems] = useState<LaravelPaginated<Paiement> | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const [typeFilter, setTypeFilter] = useState('')
+  const [statutFilter, setStatutFilter] = useState('')
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const filtersReady = useRef(false)
+
+  const paiements = items?.data ?? []
+
+  const load = useCallback(async (
+    p: number, s: string, t: string, st: string, df: string, dt: string,
+  ) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await getGerantePaiements({
+        page: p,
+        per_page: 20,
+        search: s || undefined,
+        type: t || undefined,
+        statut: st || undefined,
+        date_from: df || undefined,
+        date_to: dt || undefined,
+      })
+      setItems(data)
+      setPage(p)
+    } catch {
+      setError('Impossible de charger les paiements.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load(1, search, typeFilter, statutFilter, dateFrom, dateTo)
+    filtersReady.current = true
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!filtersReady.current) return
+    void load(1, search, typeFilter, statutFilter, dateFrom, dateTo)
+  }, [search, typeFilter, statutFilter, dateFrom, dateTo, load])
+
+  const inputClass = 'rounded-xl border border-gray-200 bg-white px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20'
+
+  return (
+    <GeranteLayout>
+    <div className="p-4 sm:p-6">
+      <div className="mx-auto max-w-5xl">
+        {/* En-tete */}
+        <div className="mb-6">
+          <h1 className="text-2xl font-black text-gray-900">Paiements</h1>
+          <p className="mt-1 text-sm text-gray-500">Historique de tous les paiements (lecture seule)</p>
+        </div>
+
+        {/* Filtres */}
+        <div className="mb-4 flex flex-wrap gap-2">
+          <input
+            className={inputClass}
+            type="text"
+            placeholder="Rechercher (recu, nom, telephone...)"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <select className={inputClass} value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)}>
+            <option value="">Tous les types</option>
+            {(Object.keys(TYPE_LABELS) as PaymentType[]).map((t) => (
+              <option key={t} value={t}>{TYPE_LABELS[t]}</option>
+            ))}
+          </select>
+          <select className={inputClass} value={statutFilter} onChange={(e) => setStatutFilter(e.target.value)}>
+            <option value="">Tous les statuts</option>
+            {(Object.keys(STATUS_LABELS) as PaymentStatus[]).map((s) => (
+              <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+            ))}
+          </select>
+          <input className={inputClass} type="date" value={dateFrom} max={today} onChange={(e) => setDateFrom(e.target.value)} />
+          <input className={inputClass} type="date" value={dateTo} max={today} onChange={(e) => setDateTo(e.target.value)} />
+        </div>
+
+        {error && <p className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>}
+
+        {/* Liste */}
+        <div className="rounded-2xl border border-gray-100 bg-white shadow-sm">
+          {loading ? (
+            <div className="flex items-center justify-center py-16">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-[#e91e63] border-t-transparent" />
+            </div>
+          ) : paiements.length === 0 ? (
+            <p className="py-16 text-center text-sm text-gray-400">Aucun paiement trouve.</p>
+          ) : (
+            <div className="divide-y divide-gray-50">
+              {paiements.map((p) => {
+                const clientName = p.client
+                  ? `${p.client.prenom} ${p.client.nom}`
+                  : p.reservation?.client
+                    ? `${p.reservation.client.prenom} ${p.reservation.client.nom}`
+                    : '—'
+
+                return (
+                  <div key={p.id} className="flex items-center gap-4 px-5 py-4">
+                    {/* Date + recu */}
+                    <div className="w-28 shrink-0">
+                      <p className="text-[12px] font-bold text-gray-800">{formatDate(p.date_paiement)}</p>
+                      <p className="text-[11px] text-gray-400">{p.numero_recu}</p>
+                    </div>
+
+                    {/* Client + reservation */}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[13px] font-semibold text-gray-900">{clientName}</p>
+                      {p.reservation_id && (
+                        <p className="text-[11px] text-gray-400">Resa #{p.reservation_id}</p>
+                      )}
+                    </div>
+
+                    {/* Type */}
+                    <span className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold ${TYPE_COLORS[p.type]}`}>
+                      {TYPE_LABELS[p.type]}
+                    </span>
+
+                    {/* Montant */}
+                    <p className="w-28 shrink-0 text-right text-[14px] font-black text-gray-900">
+                      {formatAmount(p.montant)} <span className="text-[11px] font-normal text-gray-400">FCFA</span>
+                    </p>
+
+                    {/* Statut */}
+                    <span className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold ${STATUS_COLORS[p.statut]}`}>
+                      {STATUS_LABELS[p.statut]}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Pagination */}
+        {items && items.last_page > 1 && (
+          <div className="mt-4 flex items-center justify-between">
+            <p className="text-[12px] text-gray-400">
+              Page {items.current_page} / {items.last_page} — {items.total} paiements
+            </p>
+            <div className="flex gap-2">
+              <button
+                disabled={items.current_page <= 1}
+                onClick={() => void load(page - 1, search, typeFilter, statutFilter, dateFrom, dateTo)}
+                className="rounded-xl border border-gray-200 px-3 py-1.5 text-[12px] font-semibold disabled:opacity-40 hover:bg-gray-50"
+              >
+                Precedent
+              </button>
+              <button
+                disabled={items.current_page >= items.last_page}
+                onClick={() => void load(page + 1, search, typeFilter, statutFilter, dateFrom, dateTo)}
+                className="rounded-xl border border-gray-200 px-3 py-1.5 text-[12px] font-semibold disabled:opacity-40 hover:bg-gray-50"
+              >
+                Suivant
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+    </GeranteLayout>
+  )
+}

--- a/frontend/src/features/gerante/GeranteReservationsPage.tsx
+++ b/frontend/src/features/gerante/GeranteReservationsPage.tsx
@@ -236,7 +236,7 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
   const [date, setDate] = useState(new Date().toISOString().slice(0, 10))
   const [heure, setHeure] = useState('10:00')
   const [notes, setNotes] = useState('')
-  const [enregistrerAcompte, setEnregistrerAcompte] = useState(false)
+  const [typePaiement, setTypePaiement] = useState<'acompte' | 'soldee'>('acompte')
   const [modePaiement, setModePaiement] = useState('especes')
 
   const [saving, setSaving] = useState(false)
@@ -304,13 +304,13 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
     setSaving(true)
     try {
       await createGeranteReservation({
-        client_id:             clientId,
-        date_reservation:      date,
-        heure_debut:           heure,
-        details:               [{ coiffure_id: coiffureId, variante_coiffure_id: varianteId, quantite: 1 }],
-        notes:                 notes || undefined,
-        enregistrer_acompte:   enregistrerAcompte || undefined,
-        mode_paiement_acompte: enregistrerAcompte ? modePaiement : undefined,
+        client_id:        clientId,
+        date_reservation: date,
+        heure_debut:      heure,
+        details:          [{ coiffure_id: coiffureId, variante_coiffure_id: varianteId, quantite: 1 }],
+        notes:            notes || undefined,
+        type_paiement:    typePaiement,
+        mode_paiement:    modePaiement,
       })
       onSaved()
     } catch (err: unknown) {
@@ -454,55 +454,75 @@ function NouvelleReservationModal({ onClose, onSaved }: NouvelleReservationModal
             />
           </div>
 
-          {/* Acompte */}
+          {/* Paiement : radio acompte / soldee */}
           <div className="rounded-xl border border-gray-100 bg-gray-50 p-3">
-            {/* Montant de l acompte calcule en temps reel des la selection de la variante */}
-            {acompteEstime !== null && acompteEstime > 0 && (
-              <div className="mb-3 rounded-lg bg-[#fff2f7] px-3 py-2">
-                <p className="text-[10px] font-black uppercase tracking-widest text-[#c41468]">
-                  Acompte attendu
-                </p>
-                <p className="mt-0.5 text-lg font-black text-[#c41468]">
-                  {acompteEstime.toLocaleString('fr-FR')} FCFA
-                </p>
-                <p className="text-[10px] text-[#c41468]/60">
-                  {catSettings.pourcentage_acompte > 0
-                    ? `${catSettings.pourcentage_acompte}% du prix de la prestation`
-                    : 'Montant fixe configure'}
-                </p>
-              </div>
-            )}
-            <label className="flex cursor-pointer items-center gap-2">
-              <input
-                type="checkbox"
-                checked={enregistrerAcompte}
-                onChange={(e) => setEnregistrerAcompte(e.target.checked)}
-                className="h-4 w-4 rounded accent-[#e91e63]"
-              />
-              <span className="text-[13px] font-semibold text-gray-700">Encaisser l&apos;acompte maintenant</span>
-            </label>
-            {enregistrerAcompte && (
-              <div className="mt-3">
-                <label className="mb-1 block text-[12px] font-semibold text-gray-700">Mode de paiement</label>
-                <select
-                  value={modePaiement}
-                  onChange={(e) => setModePaiement(e.target.value)}
-                  className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
-                >
-                  {PAYMENT_MODES.map((m) => (
-                    <option key={m.value} value={m.value}>{m.label}</option>
-                  ))}
-                </select>
-                {errors.mode_paiement_acompte && (
-                  <p className="mt-1 text-[11px] text-red-500">{errors.mode_paiement_acompte[0]}</p>
-                )}
-              </div>
-            )}
-            {(!acompteEstime || acompteEstime === 0) && (
-              <p className="mt-2 text-[11px] text-gray-400">
-                Selectionnez une coiffure pour voir le montant de l&apos;acompte.
-              </p>
-            )}
+            <p className="mb-2 text-[12px] font-semibold text-gray-700">Mode d&apos;encaissement <span className="text-red-500">*</span></p>
+            <div className="flex flex-col gap-2">
+              {/* Option acompte */}
+              <label className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-gray-200 bg-white p-3 hover:border-[#e91e63]/40">
+                <input
+                  type="radio"
+                  name="type_paiement"
+                  value="acompte"
+                  checked={typePaiement === 'acompte'}
+                  onChange={() => setTypePaiement('acompte')}
+                  className="mt-0.5 accent-[#e91e63]"
+                />
+                <div className="flex-1">
+                  <p className="text-[13px] font-semibold text-gray-800">Encaisser l&apos;acompte</p>
+                  {selectedVariante && acompteEstime !== null && acompteEstime > 0 ? (
+                    <p className="mt-0.5 text-[12px] font-bold text-[#c41468]">
+                      {acompteEstime.toLocaleString('fr-FR')} FCFA
+                      <span className="ml-1 font-normal text-[#c41468]/60">
+                        ({catSettings.pourcentage_acompte > 0 ? `${catSettings.pourcentage_acompte}%` : 'montant fixe'})
+                      </span>
+                    </p>
+                  ) : (
+                    <p className="mt-0.5 text-[11px] text-gray-400">Selectionnez une coiffure pour voir le montant</p>
+                  )}
+                </div>
+              </label>
+
+              {/* Option soldee */}
+              <label className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-gray-200 bg-white p-3 hover:border-[#e91e63]/40">
+                <input
+                  type="radio"
+                  name="type_paiement"
+                  value="soldee"
+                  checked={typePaiement === 'soldee'}
+                  onChange={() => setTypePaiement('soldee')}
+                  className="mt-0.5 accent-[#e91e63]"
+                />
+                <div className="flex-1">
+                  <p className="text-[13px] font-semibold text-gray-800">Soldee (paiement complet)</p>
+                  {selectedVariante ? (
+                    <p className="mt-0.5 text-[12px] font-bold text-[#c41468]">
+                      {selectedVariante.prix.toLocaleString('fr-FR')} FCFA
+                      <span className="ml-1 font-normal text-[#c41468]/60">— tout en une fois</span>
+                    </p>
+                  ) : (
+                    <p className="mt-0.5 text-[11px] text-gray-400">Selectionnez une coiffure pour voir le montant</p>
+                  )}
+                </div>
+              </label>
+            </div>
+
+            {/* Mode de paiement — toujours visible */}
+            <div className="mt-3">
+              <label className="mb-1 block text-[12px] font-semibold text-gray-700">Mode de paiement <span className="text-red-500">*</span></label>
+              <select
+                value={modePaiement}
+                onChange={(e) => setModePaiement(e.target.value)}
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-[13px] outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20"
+              >
+                {PAYMENT_MODES.map((m) => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </select>
+              {errors.mode_paiement && (
+                <p className="mt-1 text-[11px] text-red-500">{errors.mode_paiement[0]}</p>
+              )}
+            </div>
           </div>
 
           {/* Boutons */}

--- a/frontend/src/features/gerante/reservations.api.ts
+++ b/frontend/src/features/gerante/reservations.api.ts
@@ -14,8 +14,8 @@ export type GeranteReservationForm = {
   heure_debut: string
   details: GeranteReservationDetail[]
   notes?: string
-  enregistrer_acompte?: boolean
-  mode_paiement_acompte?: string
+  type_paiement: 'acompte' | 'soldee'
+  mode_paiement: string
 }
 
 type QueryParams = {

--- a/frontend/src/layouts/GeranteLayout.tsx
+++ b/frontend/src/layouts/GeranteLayout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
-import { CalendarDays, LogOut, Menu, Users, X } from 'lucide-react'
+import { CalendarDays, CreditCard, LogOut, Menu, Users, X } from 'lucide-react'
 import { clearAuth, getUser } from '../lib/authStorage'
 import { logout as apiLogout } from '../services/authService'
 
@@ -78,6 +78,21 @@ function GeranteLayout({ children }: GeranteLayoutProps) {
         >
           <Users className="h-4 w-4 shrink-0" />
           <span className="min-w-0 flex-1 truncate">Clientes</span>
+        </NavLink>
+        <NavLink
+          to="/manager/paiements"
+          onClick={closeMobileMenu}
+          className={({ isActive }) =>
+            [
+              'flex items-center gap-3 rounded-xl px-4 py-2 text-[13px] font-semibold transition',
+              isActive
+                ? 'bg-[#e91e63] text-white shadow-[0_14px_30px_-18px_rgba(233,30,99,0.9)]'
+                : 'text-white/85 hover:bg-white/8 hover:text-white',
+            ].join(' ')
+          }
+        >
+          <CreditCard className="h-4 w-4 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">Paiements</span>
         </NavLink>
       </nav>
 


### PR DESCRIPTION
…x CA

Point 2 — Gerante :
- Radio boutons acompte/soldee remplacent la case a cocher optionnelle
- Acompte : Paiement type=acompte, statut=acompte_paye
- Soldee : Paiement type=complet, montant total, statut=en_cours
- Notification WhatsApp+email cliente dispatchee dans les deux cas
- Notification aussi quand gerante enregistre le solde a la cloture (terminee)

Point 3 — CA et logs :
- DashboardController et RapportStatistiqueController : remboursements soustraits du CA affiche (entrees - remboursements = CA net)
- PaiementController admin : logs SystemLogger sur store/update/cancel/destroy

Gerante vue paiements :
- GET /api/gerante/paiements (lecture seule, sans creation)
- GerantePaiementsPage avec filtres date/type/statut/recherche
- Lien Paiements ajoute dans GeranteLayout