### PR TITLE
feat(securite): renommage route admin /admin → /console-thomas

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,25 +81,25 @@ function App() {
       <Route path="/categories/:categoryId" element={<ClientCategoryPage />} />
       <Route path="/avis/:token" element={<AvisPage />} />
       <Route path="/login" element={<LoginPage />} />
-      <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />
-      <Route path="/admin/dashboard" element={<AdminRoute><AdminDashboardPage /></AdminRoute>} />
-      <Route path="/admin/clients" element={<AdminRoute><ClientsPage /></AdminRoute>} />
-      <Route path="/admin/reservations" element={<AdminRoute><ReservationsPage /></AdminRoute>} />
-      <Route path="/admin/paiements" element={<AdminRoute><PaymentsPage /></AdminRoute>} />
-      <Route path="/admin/depenses" element={<AdminRoute><ExpensesPage /></AdminRoute>} />
-      <Route path="/admin/rapports" element={<AdminRoute><ReportsPage /></AdminRoute>} />
-      <Route path="/admin/avis" element={<AdminRoute><ReviewsPage /></AdminRoute>} />
-      <Route path="/admin/catalogue" element={<AdminRoute><CatalogueOverviewPage /></AdminRoute>} />
-      <Route path="/admin/catalogue/categories-coiffures" element={<AdminRoute><CategoriesCoiffuresPage /></AdminRoute>} />
-      <Route path="/admin/catalogue/coiffures" element={<AdminRoute><CoiffuresPage /></AdminRoute>} />
-      <Route path="/admin/catalogue/variantes" element={<AdminRoute><VariantesCoiffuresPage /></AdminRoute>} />
-      <Route path="/admin/catalogue/options" element={<AdminRoute><OptionsCoiffuresPage /></AdminRoute>} />
-      <Route path="/admin/personnel" element={<AdminRoute><PersonnelOverviewPage /></AdminRoute>} />
-      <Route path="/admin/personnel/gerantes" element={<AdminRoute><GerantesPage /></AdminRoute>} />
-      <Route path="/admin/personnel/coiffeuses" element={<AdminRoute><CoiffeusesPage /></AdminRoute>} />
-      <Route path="/admin/promotions" element={<AdminRoute><PromotionsPage /></AdminRoute>} />
-      <Route path="/admin/logs" element={<AdminRoute><LogsPage /></AdminRoute>} />
-      <Route path="/admin/parametres" element={<AdminRoute><SettingsPage /></AdminRoute>} />
+      <Route path="/console-thomas" element={<Navigate to="/console-thomas/dashboard" replace />} />
+      <Route path="/console-thomas/dashboard" element={<AdminRoute><AdminDashboardPage /></AdminRoute>} />
+      <Route path="/console-thomas/clients" element={<AdminRoute><ClientsPage /></AdminRoute>} />
+      <Route path="/console-thomas/reservations" element={<AdminRoute><ReservationsPage /></AdminRoute>} />
+      <Route path="/console-thomas/paiements" element={<AdminRoute><PaymentsPage /></AdminRoute>} />
+      <Route path="/console-thomas/depenses" element={<AdminRoute><ExpensesPage /></AdminRoute>} />
+      <Route path="/console-thomas/rapports" element={<AdminRoute><ReportsPage /></AdminRoute>} />
+      <Route path="/console-thomas/avis" element={<AdminRoute><ReviewsPage /></AdminRoute>} />
+      <Route path="/console-thomas/catalogue" element={<AdminRoute><CatalogueOverviewPage /></AdminRoute>} />
+      <Route path="/console-thomas/catalogue/categories-coiffures" element={<AdminRoute><CategoriesCoiffuresPage /></AdminRoute>} />
+      <Route path="/console-thomas/catalogue/coiffures" element={<AdminRoute><CoiffuresPage /></AdminRoute>} />
+      <Route path="/console-thomas/catalogue/variantes" element={<AdminRoute><VariantesCoiffuresPage /></AdminRoute>} />
+      <Route path="/console-thomas/catalogue/options" element={<AdminRoute><OptionsCoiffuresPage /></AdminRoute>} />
+      <Route path="/console-thomas/personnel" element={<AdminRoute><PersonnelOverviewPage /></AdminRoute>} />
+      <Route path="/console-thomas/personnel/gerantes" element={<AdminRoute><GerantesPage /></AdminRoute>} />
+      <Route path="/console-thomas/personnel/coiffeuses" element={<AdminRoute><CoiffeusesPage /></AdminRoute>} />
+      <Route path="/console-thomas/promotions" element={<AdminRoute><PromotionsPage /></AdminRoute>} />
+      <Route path="/console-thomas/logs" element={<AdminRoute><LogsPage /></AdminRoute>} />
+      <Route path="/console-thomas/parametres" element={<AdminRoute><SettingsPage /></AdminRoute>} />
       <Route path="/manager" element={<Navigate to="/manager/reservations" replace />} />
       <Route path="/manager/dashboard" element={<Navigate to="/manager/reservations" replace />} />
       <Route

--- a/frontend/src/features/admin/catalogue/CatalogueOverviewPage.tsx
+++ b/frontend/src/features/admin/catalogue/CatalogueOverviewPage.tsx
@@ -20,22 +20,22 @@ type CatalogueStats = {
 const modules = [
   {
     label: 'Categories',
-    path: '/admin/catalogue/categories-coiffures',
+    path: '/console-thomas/catalogue/categories-coiffures',
     description: 'Familles de prestations pour structurer le catalogue.',
   },
   {
     label: 'Coiffures',
-    path: '/admin/catalogue/coiffures',
+    path: '/console-thomas/catalogue/coiffures',
     description: 'Prestations principales visibles et reservables.',
   },
   {
     label: 'Variantes',
-    path: '/admin/catalogue/variantes',
+    path: '/console-thomas/catalogue/variantes',
     description: 'Prix, durees et formats rattaches aux coiffures.',
   },
   {
     label: 'Options',
-    path: '/admin/catalogue/options',
+    path: '/console-thomas/catalogue/options',
     description: 'Supplements et personnalisations du service.',
   },
 ]
@@ -115,7 +115,7 @@ function CatalogueOverviewPage() {
               <li className="rounded-lg bg-[#fff7fb] px-3 py-3">3. Ajouter les coiffures.</li>
               <li className="rounded-lg bg-[#fff7fb] px-3 py-3">4. Ajouter les variantes et prix.</li>
             </ol>
-            <NavLink to="/admin/catalogue/coiffures" className={`mt-5 inline-flex ${primaryButtonClass}`}>
+            <NavLink to="/console-thomas/catalogue/coiffures" className={`mt-5 inline-flex ${primaryButtonClass}`}>
               Ajouter une coiffure
             </NavLink>
           </Panel>

--- a/frontend/src/features/admin/catalogue/components/CatalogueLayout.tsx
+++ b/frontend/src/features/admin/catalogue/components/CatalogueLayout.tsx
@@ -3,10 +3,10 @@ import { NavLink } from 'react-router-dom'
 import AdminLayout from '../../../../layouts/AdminLayout'
 
 const tabs = [
-  { label: 'Vue catalogue', path: '/admin/catalogue' },
-  { label: 'Categories', path: '/admin/catalogue/categories-coiffures' },
-  { label: 'Coiffures', path: '/admin/catalogue/coiffures' },
-  { label: 'Options', path: '/admin/catalogue/options' },
+  { label: 'Vue catalogue', path: '/console-thomas/catalogue' },
+  { label: 'Categories', path: '/console-thomas/catalogue/categories-coiffures' },
+  { label: 'Coiffures', path: '/console-thomas/catalogue/coiffures' },
+  { label: 'Options', path: '/console-thomas/catalogue/options' },
 ]
 
 type CatalogueLayoutProps = {
@@ -35,7 +35,7 @@ function CatalogueLayout({ title, subtitle, children, action }: CatalogueLayoutP
           <NavLink
             key={tab.path}
             to={tab.path}
-            end={tab.path === '/admin/catalogue'}
+            end={tab.path === '/console-thomas/catalogue'}
             className={({ isActive }) =>
               [
                 'whitespace-nowrap rounded-lg px-4 py-2 text-sm font-bold transition',

--- a/frontend/src/features/admin/dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin/dashboard/AdminDashboardPage.tsx
@@ -309,7 +309,7 @@ function QuickPayment({ available, message }: { available: boolean; message?: st
           </p>
           <button
             type="button"
-            onClick={() => navigate('/admin/paiements')}
+            onClick={() => navigate('/console-thomas/paiements')}
             className="w-full rounded-lg bg-[#e91e63] px-5 py-3 text-sm font-bold text-white"
           >
             Ouvrir les paiements

--- a/frontend/src/features/admin/personnel/PersonnelOverviewPage.tsx
+++ b/frontend/src/features/admin/personnel/PersonnelOverviewPage.tsx
@@ -15,7 +15,7 @@ type PersonnelStats = {
 const modules = [
   {
     label: 'Gerantes',
-    path: '/admin/personnel/gerantes',
+    path: '/console-thomas/personnel/gerantes',
     description: 'Comptes responsables pouvant acceder aux espaces internes.',
     icon: ShieldCheck,
     statKey: 'gerantes',
@@ -23,7 +23,7 @@ const modules = [
   },
   {
     label: 'Coiffeuses',
-    path: '/admin/personnel/coiffeuses',
+    path: '/console-thomas/personnel/coiffeuses',
     description: 'Equipe operationnelle, commissions et disponibilite.',
     icon: Scissors,
     statKey: 'coiffeuses',
@@ -124,7 +124,7 @@ function PersonnelOverviewPage() {
                 Suivre la commission de chaque coiffeuse depuis sa fiche.
               </div>
             </div>
-            <NavLink to="/admin/personnel/coiffeuses" className={`mt-5 inline-flex items-center gap-2 ${primaryButtonClass}`}>
+            <NavLink to="/console-thomas/personnel/coiffeuses" className={`mt-5 inline-flex items-center gap-2 ${primaryButtonClass}`}>
               <Users className="h-4 w-4" />
               Voir l equipe
             </NavLink>

--- a/frontend/src/features/admin/personnel/components/PersonnelLayout.tsx
+++ b/frontend/src/features/admin/personnel/components/PersonnelLayout.tsx
@@ -3,9 +3,9 @@ import { NavLink } from 'react-router-dom'
 import AdminLayout from '../../../../layouts/AdminLayout'
 
 const tabs = [
-  { label: 'Vue personnel', path: '/admin/personnel' },
-  { label: 'Gerantes', path: '/admin/personnel/gerantes' },
-  { label: 'Coiffeuses', path: '/admin/personnel/coiffeuses' },
+  { label: 'Vue personnel', path: '/console-thomas/personnel' },
+  { label: 'Gerantes', path: '/console-thomas/personnel/gerantes' },
+  { label: 'Coiffeuses', path: '/console-thomas/personnel/coiffeuses' },
 ]
 
 type PersonnelLayoutProps = {
@@ -34,7 +34,7 @@ function PersonnelLayout({ title, subtitle, children, action }: PersonnelLayoutP
           <NavLink
             key={tab.path}
             to={tab.path}
-            end={tab.path === '/admin/personnel'}
+            end={tab.path === '/console-thomas/personnel'}
             className={({ isActive }) =>
               [
                 'whitespace-nowrap rounded-lg px-4 py-2 text-sm font-bold transition',

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -44,39 +44,39 @@ type Section = {
 }
 
 const sections: Section[] = [
-  { label: 'Tableau de bord', path: '/admin/dashboard', icon: Gauge },
-  { label: 'Reservations', path: '/admin/reservations', icon: CalendarDays },
-  { label: 'Clients', path: '/admin/clients', icon: Users },
+  { label: 'Tableau de bord', path: '/console-thomas/dashboard', icon: Gauge },
+  { label: 'Reservations', path: '/console-thomas/reservations', icon: CalendarDays },
+  { label: 'Clients', path: '/console-thomas/clients', icon: Users },
   {
     label: 'Catalogue',
-    path: '/admin/catalogue',
+    path: '/console-thomas/catalogue',
     icon: BookOpen,
     children: [
-      { label: 'Categories coiffures', path: '/admin/catalogue/categories-coiffures' },
-      { label: 'Coiffures', path: '/admin/catalogue/coiffures' },
-      { label: 'Options', path: '/admin/catalogue/options' },
+      { label: 'Categories coiffures', path: '/console-thomas/catalogue/categories-coiffures' },
+      { label: 'Coiffures', path: '/console-thomas/catalogue/coiffures' },
+      { label: 'Options', path: '/console-thomas/catalogue/options' },
     ],
   },
   {
     label: 'Personnel',
-    path: '/admin/personnel',
+    path: '/console-thomas/personnel',
     icon: ClipboardList,
     children: [
-      { label: 'Gerantes', path: '/admin/personnel/gerantes' },
-      { label: 'Coiffeuses', path: '/admin/personnel/coiffeuses' },
+      { label: 'Gerantes', path: '/console-thomas/personnel/gerantes' },
+      { label: 'Coiffeuses', path: '/console-thomas/personnel/coiffeuses' },
     ],
   },
-  { label: 'Paiements & Recus', path: '/admin/paiements', icon: Receipt },
-  { label: 'Caisse', path: '/admin/caisse', icon: Wallet, comingSoon: true },
-  { label: 'Depenses', path: '/admin/depenses', icon: CircleDollarSign },
-  { label: 'Commissions', path: '/admin/commissions', icon: Percent, comingSoon: true },
-  { label: 'Promotions & Fidelite', path: '/admin/promotions', icon: Gift },
-  { label: 'Avis clientes', path: '/admin/avis', icon: Star },
-  { label: 'Messages WhatsApp', path: '/admin/messages', icon: MessageCircle, comingSoon: true },
-  { label: 'Photos prestations', path: '/admin/photos', icon: Camera, comingSoon: true },
-  { label: 'Rapports & Statistiques', path: '/admin/rapports', icon: BarChart3 },
-  { label: 'Logs systeme', path: '/admin/logs', icon: ShoppingBag },
-  { label: 'Parametres', path: '/admin/parametres', icon: Settings },
+  { label: 'Paiements & Recus', path: '/console-thomas/paiements', icon: Receipt },
+  { label: 'Caisse', path: '/console-thomas/caisse', icon: Wallet, comingSoon: true },
+  { label: 'Depenses', path: '/console-thomas/depenses', icon: CircleDollarSign },
+  { label: 'Commissions', path: '/console-thomas/commissions', icon: Percent, comingSoon: true },
+  { label: 'Promotions & Fidelite', path: '/console-thomas/promotions', icon: Gift },
+  { label: 'Avis clientes', path: '/console-thomas/avis', icon: Star },
+  { label: 'Messages WhatsApp', path: '/console-thomas/messages', icon: MessageCircle, comingSoon: true },
+  { label: 'Photos prestations', path: '/console-thomas/photos', icon: Camera, comingSoon: true },
+  { label: 'Rapports & Statistiques', path: '/console-thomas/rapports', icon: BarChart3 },
+  { label: 'Logs systeme', path: '/console-thomas/logs', icon: ShoppingBag },
+  { label: 'Parametres', path: '/console-thomas/parametres', icon: Settings },
 ]
 
 function Brand() {
@@ -99,8 +99,8 @@ function AdminLayout({ children }: AdminLayoutProps) {
   const user = getUser()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
-    '/admin/catalogue': true,
-    '/admin/personnel': true,
+    '/console-thomas/catalogue': true,
+    '/console-thomas/personnel': true,
   })
   const [comingSoonToast, setComingSoonToast] = useState(false)
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -36,7 +36,7 @@ function LoginPage() {
       persistRememberMe(rememberMe)
 
       if (response.user.role === 'admin') {
-        navigate('/admin/dashboard')
+        navigate('/console-thomas/dashboard')
         return
       }
 


### PR DESCRIPTION
Rend l URL de l espace admin moins previsible (securite par obscurite, couche supplementaire au-dessus de auth.token + role:admin). Seules les routes React Router sont modifiees — les appels API backend /api/admin/* restent inchanges (deja proteges cote serveur).