### PR TITLE
feat(auth): masquer la page de connexion admin derriere /console-thomas

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,8 +80,7 @@ function App() {
       <Route path="/categories" element={<ClientCategoryPage />} />
       <Route path="/categories/:categoryId" element={<ClientCategoryPage />} />
       <Route path="/avis/:token" element={<AvisPage />} />
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/console-thomas" element={<Navigate to="/console-thomas/dashboard" replace />} />
+      <Route path="/console-thomas" element={<LoginPage />} />
       <Route path="/console-thomas/dashboard" element={<AdminRoute><AdminDashboardPage /></AdminRoute>} />
       <Route path="/console-thomas/clients" element={<AdminRoute><ClientsPage /></AdminRoute>} />
       <Route path="/console-thomas/reservations" element={<AdminRoute><ReservationsPage /></AdminRoute>} />

--- a/frontend/src/features/admin/dashboard/AdminDashboardPage.tsx
+++ b/frontend/src/features/admin/dashboard/AdminDashboardPage.tsx
@@ -387,7 +387,7 @@ function AdminDashboardPage() {
       .then(setDashboard)
       .catch(() => {
         clearAuth()
-        navigate('/login', { replace: true })
+        navigate('/console-thomas', { replace: true })
       })
       .finally(() => setLoading(false))
   }, [navigate])

--- a/frontend/src/features/auth/RequireAuth.tsx
+++ b/frontend/src/features/auth/RequireAuth.tsx
@@ -11,11 +11,11 @@ function RequireAuth({ children, role }: RequireAuthProps) {
   const user = getUser()
 
   if (!user) {
-    return <Navigate to="/login" replace />
+    return <Navigate to="/console-thomas" replace />
   }
 
   if (role && user.role !== role) {
-    return <Navigate to="/login" replace />
+    return <Navigate to="/console-thomas" replace />
   }
 
   return children

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -119,7 +119,7 @@ function AdminLayout({ children }: AdminLayoutProps) {
     }
     clearAuth()
     closeMobileMenu()
-    navigate('/login', { replace: true })
+    navigate('/console-thomas', { replace: true })
   }
 
   const renderNavigation = () => (

--- a/frontend/src/layouts/GeranteLayout.tsx
+++ b/frontend/src/layouts/GeranteLayout.tsx
@@ -39,7 +39,7 @@ function GeranteLayout({ children }: GeranteLayoutProps) {
     }
     clearAuth()
     closeMobileMenu()
-    navigate('/login', { replace: true })
+    navigate('/console-thomas', { replace: true })
   }
 
   const renderNavigation = () => (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,16 +1,25 @@
-import { useState, type FormEvent } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import AuthLayout from '../layouts/AuthLayout'
 import HeroPanel from '../components/auth/HeroPanel'
 import LoginPanel from '../components/auth/LoginPanel'
 import { login } from '../services/authService'
 import {
+  getUser,
   setRememberMe as persistRememberMe,
   setUser,
 } from '../lib/authStorage'
 
 function LoginPage() {
   const navigate = useNavigate()
+
+  // Déjà connecté : évite d'afficher le formulaire inutilement
+  useEffect(() => {
+    const user = getUser()
+    if (user?.role === 'admin') navigate('/console-thomas/dashboard', { replace: true })
+    else if (user?.role === 'gerante') navigate('/manager/reservations', { replace: true })
+  }, [navigate])
+
   const [identifier, setIdentifier] = useState('')
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
@@ -45,7 +54,7 @@ function LoginPage() {
         return
       }
 
-      navigate('/login')
+      navigate('/')
     } catch {
       setError('Impossible de vous connecter. Verifiez vos identifiants.')
     } finally {


### PR DESCRIPTION
- /login supprime et pointe desormais vers 404
- /console-thomas devient la page de connexion
- RequireAuth et tous les layouts redirigent vers /console-thomas
- Detection session active : admin/gerante deja connectes bypasse le formulaire