### PR TITLE
feat(signalements): systeme de signalement gerante -> admin avec cloc…

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/SignalementController.php
+++ b/backend/app/Http/Controllers/Api/Admin/SignalementController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Signalement;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SignalementController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $signalements = Signalement::query()
+            ->with('gerante')
+            ->when($request->filled('traite'), fn ($q) => $q->where('traite', $request->boolean('traite')))
+            ->when($request->filled('urgence'), fn ($q) => $q->where('urgence', $request->string('urgence')->toString()))
+            ->latest()
+            ->paginate(30);
+
+        return response()->json(['data' => $signalements]);
+    }
+
+    public function nonLusCount(): JsonResponse
+    {
+        return response()->json([
+            'count' => Signalement::query()->where('lu_par_admin', false)->count(),
+        ]);
+    }
+
+    public function marquerLu(Signalement $signalement): JsonResponse
+    {
+        if (! $signalement->lu_par_admin) {
+            $signalement->update([
+                'lu_par_admin' => true,
+                'lu_at'        => now(),
+            ]);
+        }
+
+        return response()->json(['data' => $signalement]);
+    }
+
+    public function marquerTraite(Request $request, Signalement $signalement): JsonResponse
+    {
+        $data = $request->validate([
+            'note_admin' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $signalement->update([
+            'traite'       => true,
+            'traite_at'    => now(),
+            'lu_par_admin' => true,
+            'lu_at'        => $signalement->lu_at ?? now(),
+            'note_admin'   => $data['note_admin'] ?? null,
+        ]);
+
+        return response()->json([
+            'message' => 'Signalement marque comme traite.',
+            'data'    => $signalement->fresh('gerante'),
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/Gerante/SignalementController.php
+++ b/backend/app/Http/Controllers/Api/Gerante/SignalementController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Api\Gerante;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\SendSignalementNotification;
+use App\Models\Signalement;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class SignalementController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $signalements = Signalement::query()
+            ->where('gerante_id', $request->user()->id)
+            ->latest()
+            ->paginate(20);
+
+        return response()->json(['data' => $signalements]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'type'        => ['required', Rule::in(['produit', 'materiel', 'autre'])],
+            'titre'       => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:2000'],
+            'urgence'     => ['required', Rule::in(['normale', 'urgente'])],
+        ]);
+
+        $signalement = Signalement::query()->create([
+            ...$data,
+            'gerante_id' => $request->user()->id,
+        ]);
+
+        SendSignalementNotification::dispatch($signalement->id);
+
+        return response()->json([
+            'message' => 'Signalement envoye.',
+            'data'    => $signalement->load('gerante'),
+        ], 201);
+    }
+}

--- a/backend/app/Jobs/SendSignalementNotification.php
+++ b/backend/app/Jobs/SendSignalementNotification.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\SignalementAdminMail;
+use App\Models\Signalement;
+use App\Models\User;
+use App\Services\WhatsappService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class SendSignalementNotification implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function backoff(): array
+    {
+        return [10, 30, 60];
+    }
+
+    public function __construct(public readonly int $signalementId)
+    {
+    }
+
+    public function handle(WhatsappService $whatsapp): void
+    {
+        $signalement = Signalement::query()->with('gerante')->find($this->signalementId);
+
+        if (! $signalement) {
+            Log::warning('SendSignalementNotification : signalement introuvable', [
+                'signalement_id' => $this->signalementId,
+            ]);
+
+            return;
+        }
+
+        $admins = User::query()->where('role', 'admin')->get();
+
+        foreach ($admins as $admin) {
+            // Email
+            if ($admin->email) {
+                try {
+                    Mail::to($admin->email)->send(new SignalementAdminMail($signalement));
+                } catch (\Throwable $e) {
+                    Log::warning('SendSignalementNotification : email echec', [
+                        'admin_id' => $admin->id,
+                        'error'    => $e->getMessage(),
+                    ]);
+                }
+            }
+
+            // WhatsApp
+            if ($admin->telephone ?? null) {
+                $urgenceLabel = $signalement->urgence === 'urgente' ? '🔴 URGENT' : '🟡 Normal';
+                $typeLabel    = match ($signalement->type) {
+                    'produit'   => 'Produit / Fourniture',
+                    'materiel'  => 'Equipement / Materiel',
+                    default     => 'Autre',
+                };
+                $geranteName  = $signalement->gerante?->name ?? 'La gerante';
+
+                $message = "📢 *Nouveau signalement — Bichette Thomas*\n\n"
+                    . "*{$urgenceLabel}*\n"
+                    . "Categorie : {$typeLabel}\n"
+                    . "Objet : {$signalement->titre}\n"
+                    . ($signalement->description ? "Details : {$signalement->description}\n" : '')
+                    . "\nEnvoye par {$geranteName}.";
+
+                $whatsapp->send($admin->telephone, $message, 'signalement');
+            }
+        }
+    }
+}

--- a/backend/app/Mail/SignalementAdminMail.php
+++ b/backend/app/Mail/SignalementAdminMail.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Signalement;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class SignalementAdminMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public readonly Signalement $signalement)
+    {
+    }
+
+    public function envelope(): Envelope
+    {
+        $urgence = $this->signalement->urgence === 'urgente' ? '[URGENT] ' : '';
+
+        return new Envelope(
+            subject: "{$urgence}Signalement : {$this->signalement->titre}"
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.signalement-admin',
+            with: ['signalement' => $this->signalement],
+        );
+    }
+}

--- a/backend/app/Models/Signalement.php
+++ b/backend/app/Models/Signalement.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['gerante_id', 'type', 'titre', 'description', 'urgence', 'lu_par_admin', 'lu_at', 'traite', 'traite_at', 'note_admin'])]
+class Signalement extends Model
+{
+    use HasFactory;
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function gerante(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'gerante_id');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'lu_par_admin' => 'boolean',
+            'lu_at'        => 'datetime',
+            'traite'       => 'boolean',
+            'traite_at'    => 'datetime',
+        ];
+    }
+}

--- a/backend/database/migrations/2026_05_25_141138_create_signalements_table.php
+++ b/backend/database/migrations/2026_05_25_141138_create_signalements_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('signalements', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('gerante_id')->constrained('users')->cascadeOnDelete();
+            $table->string('type'); // produit | materiel | autre
+            $table->string('titre');
+            $table->text('description')->nullable();
+            $table->string('urgence')->default('normale'); // normale | urgente
+            $table->boolean('lu_par_admin')->default(false);
+            $table->timestamp('lu_at')->nullable();
+            $table->boolean('traite')->default(false);
+            $table->timestamp('traite_at')->nullable();
+            $table->text('note_admin')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('signalements');
+    }
+};

--- a/backend/resources/views/emails/signalement-admin.blade.php
+++ b/backend/resources/views/emails/signalement-admin.blade.php
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Signalement — Bichette Thomas</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f9fafb; margin: 0; padding: 24px; }
+  .card { max-width: 560px; margin: 0 auto; background: #fff; border-radius: 16px; overflow: hidden; box-shadow: 0 4px 24px rgba(0,0,0,.08); }
+  .header { background: #e91e63; padding: 28px 32px; }
+  .header h1 { color: #fff; margin: 0; font-size: 20px; font-weight: 800; }
+  .header p { color: rgba(255,255,255,.75); margin: 4px 0 0; font-size: 13px; }
+  .body { padding: 28px 32px; }
+  .badge { display: inline-block; padding: 4px 12px; border-radius: 999px; font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: .04em; margin-bottom: 18px; }
+  .badge-urgente { background: #fee2e2; color: #b91c1c; }
+  .badge-normale  { background: #fef9c3; color: #854d0e; }
+  .row { margin-bottom: 14px; }
+  .label { font-size: 11px; font-weight: 700; text-transform: uppercase; color: #9ca3af; margin-bottom: 3px; }
+  .value { font-size: 14px; color: #111; font-weight: 600; }
+  .description { background: #f9fafb; border-radius: 8px; padding: 12px 16px; font-size: 13px; color: #374151; line-height: 1.6; }
+  .footer { padding: 16px 32px; border-top: 1px solid #f3f4f6; font-size: 12px; color: #9ca3af; text-align: center; }
+  .btn { display: inline-block; margin-top: 20px; background: #e91e63; color: #fff; text-decoration: none; padding: 10px 22px; border-radius: 8px; font-size: 13px; font-weight: 700; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="header">
+    <h1>Nouveau signalement</h1>
+    <p>Bichette Thomas — Salon de Coiffure</p>
+  </div>
+  <div class="body">
+    <span class="badge badge-{{ $signalement->urgence }}">
+      {{ $signalement->urgence === 'urgente' ? '🔴 Urgent' : '🟡 Normal' }}
+    </span>
+
+    <div class="row">
+      <div class="label">Categorie</div>
+      <div class="value">
+        @if($signalement->type === 'produit') Produit / Fourniture
+        @elseif($signalement->type === 'materiel') Equipement / Materiel
+        @else Autre
+        @endif
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="label">Objet</div>
+      <div class="value">{{ $signalement->titre }}</div>
+    </div>
+
+    @if($signalement->description)
+    <div class="row">
+      <div class="label">Details</div>
+      <div class="description">{{ $signalement->description }}</div>
+    </div>
+    @endif
+
+    <div class="row" style="margin-top:18px">
+      <div class="label">Envoye par</div>
+      <div class="value">{{ $signalement->gerante?->name ?? 'La gerante' }}</div>
+    </div>
+
+    <div class="row">
+      <div class="label">Date</div>
+      <div class="value">{{ $signalement->created_at->format('d/m/Y à H:i') }}</div>
+    </div>
+  </div>
+  <div class="footer">
+    Ce signalement est visible dans votre espace d'administration.
+  </div>
+</div>
+</body>
+</html>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -12,6 +12,8 @@ use App\Http\Controllers\Api\Admin\ClientController;
 use App\Http\Controllers\Api\Admin\DepenseController;
 use App\Http\Controllers\Api\Admin\EvenementAnalyticsController;
 use App\Http\Controllers\Api\Admin\ExportJournalController;
+use App\Http\Controllers\Api\Admin\SignalementController as AdminSignalementController;
+use App\Http\Controllers\Api\Gerante\SignalementController as GeranteSignalementController;
 use App\Http\Controllers\Api\Admin\GeranteController;
 use App\Http\Controllers\Api\Admin\ImageCoiffureController;
 use App\Http\Controllers\Api\Gerante\ClientController as GeranteClientController;
@@ -97,6 +99,10 @@ Route::middleware(['auth.token', 'role:admin', 'log.admin'])
         Route::get('dashboard', DashboardController::class)->name('dashboard');
         Route::get('rapports-statistiques', RapportStatistiqueController::class)->name('rapports-statistiques');
         Route::get('rapports/export-journal', ExportJournalController::class)->name('rapports.export-journal');
+        Route::get('signalements/non-lus-count', [AdminSignalementController::class, 'nonLusCount'])->name('signalements.non-lus-count');
+        Route::patch('signalements/{signalement}/marquer-lu', [AdminSignalementController::class, 'marquerLu'])->name('signalements.marquer-lu');
+        Route::patch('signalements/{signalement}/marquer-traite', [AdminSignalementController::class, 'marquerTraite'])->name('signalements.marquer-traite');
+        Route::apiResource('signalements', AdminSignalementController::class)->only(['index']);
         Route::patch('avis-coiffures/{avisCoiffure}/approuver', [AvisCoiffureController::class, 'approve'])->name('avis-coiffures.approve');
         Route::patch('avis-coiffures/{avisCoiffure}/rejeter', [AvisCoiffureController::class, 'reject'])->name('avis-coiffures.reject');
         Route::apiResource('avis-coiffures', AvisCoiffureController::class)
@@ -162,6 +168,8 @@ Route::middleware(['auth.token', 'role:gerante', 'log.admin'])
     ->prefix('gerante')
     ->name('gerante.')
     ->group(function (): void {
+        Route::get('signalements', [GeranteSignalementController::class, 'index'])->name('signalements.index');
+        Route::post('signalements', [GeranteSignalementController::class, 'store'])->name('signalements.store');
         Route::get('reservations', [GeranteReservationController::class, 'index'])->name('reservations.index');
         Route::post('reservations', [GeranteReservationController::class, 'store'])->name('reservations.store');
         Route::get('reservations/{reservation}', [GeranteReservationController::class, 'show'])->name('reservations.show');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,8 @@ const LogsPage = lazy(() => import('./features/admin/logs-systeme/LogsPage'))
 const GeranteReservationsPage = lazy(() => import('./features/gerante/GeranteReservationsPage'))
 const GeranteClientsPage = lazy(() => import('./features/gerante/GeranteClientsPage'))
 const GerantePaiementsPage = lazy(() => import('./features/gerante/GerantePaiementsPage'))
+const GeranteSignalementsPage = lazy(() => import('./features/gerante/GeranteSignalementsPage'))
+const AdminSignalementsPage = lazy(() => import('./features/admin/signalements/AdminSignalementsPage'))
 
 function NotFound() {
   return (
@@ -99,6 +101,7 @@ function App() {
       <Route path="/console-thomas/promotions" element={<AdminRoute><PromotionsPage /></AdminRoute>} />
       <Route path="/console-thomas/logs" element={<AdminRoute><LogsPage /></AdminRoute>} />
       <Route path="/console-thomas/parametres" element={<AdminRoute><SettingsPage /></AdminRoute>} />
+      <Route path="/console-thomas/signalements" element={<AdminRoute><AdminSignalementsPage /></AdminRoute>} />
       <Route path="/manager" element={<Navigate to="/manager/reservations" replace />} />
       <Route path="/manager/dashboard" element={<Navigate to="/manager/reservations" replace />} />
       <Route
@@ -127,6 +130,16 @@ function App() {
           <RequireAuth role="gerante">
             <Suspense fallback={<RouteSuspenseFallback />}>
               <GerantePaiementsPage />
+            </Suspense>
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/manager/signalements"
+        element={
+          <RequireAuth role="gerante">
+            <Suspense fallback={<RouteSuspenseFallback />}>
+              <GeranteSignalementsPage />
             </Suspense>
           </RequireAuth>
         }

--- a/frontend/src/features/admin/signalements/AdminSignalementsPage.tsx
+++ b/frontend/src/features/admin/signalements/AdminSignalementsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { AlertTriangle, CheckCircle2, Clock, Filter, PackageSearch, RefreshCw } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, Clock, PackageSearch, RefreshCw } from 'lucide-react'
 import AdminLayout from '../../../layouts/AdminLayout'
 import { getAdminSignalements, marquerLu, marquerTraite } from './signalements.api'
 import type { Signalement } from './signalements.types'

--- a/frontend/src/features/admin/signalements/AdminSignalementsPage.tsx
+++ b/frontend/src/features/admin/signalements/AdminSignalementsPage.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, CheckCircle2, Clock, Filter, PackageSearch, RefreshCw } from 'lucide-react'
+import AdminLayout from '../../../layouts/AdminLayout'
+import { getAdminSignalements, marquerLu, marquerTraite } from './signalements.api'
+import type { Signalement } from './signalements.types'
+
+const typeLabel = (t: string) => ({ produit: 'Produit / Fourniture', materiel: 'Equipement / Materiel', autre: 'Autre' }[t] ?? t)
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function AdminSignalementsPage() {
+  const [signalements, setSignalements] = useState<Signalement[]>([])
+  const [loading, setLoading]           = useState(true)
+  const [filtreTraite, setFiltreTraite] = useState<'tous' | 'non_traite' | 'traite'>('non_traite')
+  const [noteMap, setNoteMap]           = useState<Record<number, string>>({})
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params = filtreTraite === 'tous' ? {} : { traite: filtreTraite === 'traite' }
+      setSignalements(await getAdminSignalements(params))
+    } catch {
+      // silencieux
+    } finally {
+      setLoading(false)
+    }
+  }, [filtreTraite])
+
+  useEffect(() => { void load() }, [load])
+
+  const handleMarquerLu = async (s: Signalement) => {
+    if (s.lu_par_admin) return
+    const updated = await marquerLu(s.id)
+    setSignalements((prev) => prev.map((x) => (x.id === s.id ? updated : x)))
+  }
+
+  const handleTraite = async (s: Signalement) => {
+    const note = noteMap[s.id] ?? ''
+    const updated = await marquerTraite(s.id, note || undefined)
+    setSignalements((prev) => prev.map((x) => (x.id === s.id ? updated : x)))
+  }
+
+  return (
+    <AdminLayout>
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-bold uppercase text-[#e91e63]">Gestion</p>
+          <h1 className="mt-1 text-2xl font-black text-[#111018] sm:text-3xl">Signalements</h1>
+          <p className="mt-1 text-sm font-medium text-gray-500">Besoins signales par les gerantes du salon.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={filtreTraite}
+            onChange={(e) => setFiltreTraite(e.target.value as typeof filtreTraite)}
+            className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-medium shadow-sm outline-none focus:border-[#e91e63]"
+          >
+            <option value="non_traite">Non traites</option>
+            <option value="traite">Traites</option>
+            <option value="tous">Tous</option>
+          </select>
+          <button type="button" onClick={() => void load()} className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-bold shadow-sm hover:bg-gray-50">
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="rounded-xl border border-gray-100 bg-white p-8 text-sm font-bold text-gray-400 shadow-sm">Chargement...</div>
+      ) : signalements.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-gray-100 bg-white py-16 shadow-sm">
+          <PackageSearch className="h-10 w-10 text-gray-300" />
+          <p className="text-sm font-bold text-gray-400">Aucun signalement dans cette categorie.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {signalements.map((s) => (
+            <div
+              key={s.id}
+              className={[
+                'rounded-xl border bg-white p-5 shadow-sm transition',
+                s.urgence === 'urgente' ? 'border-red-200' : 'border-gray-100',
+                !s.lu_par_admin ? 'ring-2 ring-[#e91e63]/20' : '',
+              ].join(' ')}
+              onClick={() => void handleMarquerLu(s)}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  {/* Header */}
+                  <div className="flex flex-wrap items-center gap-2">
+                    {s.urgence === 'urgente' && <AlertTriangle className="h-4 w-4 shrink-0 text-red-500" />}
+                    {!s.lu_par_admin && <span className="h-2 w-2 shrink-0 rounded-full bg-[#e91e63]" />}
+                    <p className="font-black text-gray-950">{s.titre}</p>
+                  </div>
+
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs font-medium text-gray-400">
+                    <span>{typeLabel(s.type)}</span>
+                    <span>·</span>
+                    <span>{s.gerante?.name ?? 'Gerante'}</span>
+                    <span>·</span>
+                    <span>{formatDate(s.created_at)}</span>
+                  </div>
+
+                  {s.description && <p className="mt-2 text-sm text-gray-700">{s.description}</p>}
+
+                  {/* Note admin */}
+                  {!s.traite && (
+                    <div className="mt-3 flex gap-2">
+                      <input
+                        type="text"
+                        placeholder="Note de reponse (optionnel)..."
+                        value={noteMap[s.id] ?? ''}
+                        onChange={(e) => setNoteMap((m) => ({ ...m, [s.id]: e.target.value }))}
+                        onClick={(e) => e.stopPropagation()}
+                        className="min-w-0 flex-1 rounded-lg border border-gray-200 px-3 py-1.5 text-sm outline-none focus:border-[#e91e63]"
+                      />
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); void handleTraite(s) }}
+                        className="shrink-0 rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-black text-white hover:bg-emerald-600"
+                      >
+                        Marquer traite
+                      </button>
+                    </div>
+                  )}
+
+                  {s.note_admin && (
+                    <p className="mt-2 rounded-lg bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-800">
+                      <span className="font-black">Votre note :</span> {s.note_admin}
+                    </p>
+                  )}
+                </div>
+
+                {/* Statut badge */}
+                <div className="shrink-0">
+                  {s.traite ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-black text-emerald-700">
+                      <CheckCircle2 className="h-3 w-3" />Traite
+                    </span>
+                  ) : s.lu_par_admin ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 text-xs font-black text-blue-700">
+                      <CheckCircle2 className="h-3 w-3" />Lu
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-[#fff2f7] px-2.5 py-1 text-xs font-black text-[#e91e63]">
+                      <Clock className="h-3 w-3" />Non lu
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </AdminLayout>
+  )
+}
+
+export default AdminSignalementsPage

--- a/frontend/src/features/admin/signalements/signalements.api.ts
+++ b/frontend/src/features/admin/signalements/signalements.api.ts
@@ -5,7 +5,7 @@ type PaginatedResponse<T> = { data: { data: T[]; total: number; current_page: nu
 
 export async function getAdminSignalements(params?: { traite?: boolean; urgence?: string }) {
   const response = await apiClient.get<PaginatedResponse<Signalement>>('/admin/signalements', { params })
-  return response.data.data
+  return response.data.data.data
 }
 
 export async function getNonLusCount() {

--- a/frontend/src/features/admin/signalements/signalements.api.ts
+++ b/frontend/src/features/admin/signalements/signalements.api.ts
@@ -1,0 +1,26 @@
+import { apiClient } from '../../../lib/apiClient'
+import type { NonLusCountResponse, Signalement } from './signalements.types'
+
+type PaginatedResponse<T> = { data: { data: T[]; total: number; current_page: number; last_page: number } }
+
+export async function getAdminSignalements(params?: { traite?: boolean; urgence?: string }) {
+  const response = await apiClient.get<PaginatedResponse<Signalement>>('/admin/signalements', { params })
+  return response.data.data
+}
+
+export async function getNonLusCount() {
+  const response = await apiClient.get<NonLusCountResponse>('/admin/signalements/non-lus-count')
+  return response.data.count
+}
+
+export async function marquerLu(id: number) {
+  const response = await apiClient.patch<{ data: Signalement }>(`/admin/signalements/${id}/marquer-lu`)
+  return response.data.data
+}
+
+export async function marquerTraite(id: number, noteAdmin?: string) {
+  const response = await apiClient.patch<{ data: Signalement }>(`/admin/signalements/${id}/marquer-traite`, {
+    note_admin: noteAdmin ?? null,
+  })
+  return response.data.data
+}

--- a/frontend/src/features/admin/signalements/signalements.types.ts
+++ b/frontend/src/features/admin/signalements/signalements.types.ts
@@ -1,0 +1,28 @@
+export type SignalementType = 'produit' | 'materiel' | 'autre'
+export type SignalementUrgence = 'normale' | 'urgente'
+
+export type Signalement = {
+  id: number
+  gerante_id: number
+  type: SignalementType
+  titre: string
+  description: string | null
+  urgence: SignalementUrgence
+  lu_par_admin: boolean
+  lu_at: string | null
+  traite: boolean
+  traite_at: string | null
+  note_admin: string | null
+  created_at: string
+  updated_at: string
+  gerante?: { id: number; name: string; email: string } | null
+}
+
+export type SignalementForm = {
+  type: SignalementType
+  titre: string
+  description: string
+  urgence: SignalementUrgence
+}
+
+export type NonLusCountResponse = { count: number }

--- a/frontend/src/features/gerante/GeranteSignalementsPage.tsx
+++ b/frontend/src/features/gerante/GeranteSignalementsPage.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, CheckCircle2, Clock, PackageSearch, Send } from 'lucide-react'
+import GeranteLayout from '../../layouts/GeranteLayout'
+import { createSignalement, getGeranteSignalements } from './signalements.api'
+import type { Signalement, SignalementForm } from '../admin/signalements/signalements.types'
+
+const typeOptions = [
+  { value: 'produit',  label: 'Produit / Fourniture' },
+  { value: 'materiel', label: 'Equipement / Materiel' },
+  { value: 'autre',    label: 'Autre' },
+] as const
+
+const inputClass = 'w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-900 shadow-sm outline-none focus:border-[#e91e63] focus:ring-2 focus:ring-[#e91e63]/20'
+const labelClass = 'block text-xs font-black uppercase text-gray-500 mb-1'
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function StatutBadge({ s }: { s: Signalement }) {
+  if (s.traite) {
+    return <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-black text-emerald-700"><CheckCircle2 className="h-3 w-3" />Traite</span>
+  }
+  if (s.lu_par_admin) {
+    return <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 text-xs font-black text-blue-700"><CheckCircle2 className="h-3 w-3" />Lu</span>
+  }
+  return <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-black text-amber-700"><Clock className="h-3 w-3" />En attente</span>
+}
+
+function GeranteSignalementsPage() {
+  const [signalements, setSignalements] = useState<Signalement[]>([])
+  const [loading, setLoading]           = useState(true)
+  const [sending, setSending]           = useState(false)
+  const [success, setSuccess]           = useState(false)
+  const [error, setError]               = useState<string | null>(null)
+
+  const [form, setForm] = useState<SignalementForm>({
+    type: 'produit',
+    titre: '',
+    description: '',
+    urgence: 'normale',
+  })
+
+  const load = useCallback(async () => {
+    try {
+      setSignalements(await getGeranteSignalements())
+    } catch {
+      // silencieux
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!form.titre.trim()) return
+    setSending(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      const created = await createSignalement(form)
+      setSignalements((prev) => [created, ...prev])
+      setForm({ type: 'produit', titre: '', description: '', urgence: 'normale' })
+      setSuccess(true)
+      window.setTimeout(() => setSuccess(false), 4000)
+    } catch {
+      setError('Impossible d envoyer le signalement. Reessayez.')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <GeranteLayout>
+      <div className="mb-5">
+        <p className="text-xs font-bold uppercase text-[#e91e63]">Signalement</p>
+        <h1 className="mt-1 text-2xl font-black text-[#111018]">Signaler un besoin</h1>
+        <p className="mt-1 text-sm font-medium text-gray-500">
+          Notifiez l administratrice d un besoin urgent : produit manquant, materiel en panne, autre.
+        </p>
+      </div>
+
+      {/* Formulaire */}
+      <section className="mb-6 rounded-xl border border-[#f1e7ee] bg-white p-5 shadow-sm">
+        <h2 className="mb-4 text-base font-black text-[#111018]">Nouveau signalement</h2>
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          {/* Type + Urgence */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className={labelClass}>Categorie</label>
+              <select value={form.type} onChange={(e) => setForm((f) => ({ ...f, type: e.target.value as SignalementForm['type'] }))} className={inputClass}>
+                {typeOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelClass}>Urgence</label>
+              <div className="flex gap-2 pt-1">
+                {(['normale', 'urgente'] as const).map((u) => (
+                  <button
+                    key={u}
+                    type="button"
+                    onClick={() => setForm((f) => ({ ...f, urgence: u }))}
+                    className={[
+                      'flex-1 rounded-xl border py-2 text-sm font-black transition',
+                      form.urgence === u
+                        ? u === 'urgente'
+                          ? 'border-red-500 bg-red-500 text-white'
+                          : 'border-[#e91e63] bg-[#e91e63] text-white'
+                        : 'border-gray-200 bg-white text-gray-500 hover:border-gray-300',
+                    ].join(' ')}
+                  >
+                    {u === 'urgente' ? '🔴 Urgent' : '🟡 Normal'}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Titre */}
+          <div>
+            <label className={labelClass}>Objet <span className="text-red-500">*</span></label>
+            <input
+              type="text"
+              value={form.titre}
+              onChange={(e) => setForm((f) => ({ ...f, titre: e.target.value }))}
+              placeholder="Ex: Rupture de meches bresiliennes n°2"
+              className={inputClass}
+              required
+              maxLength={255}
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className={labelClass}>Details <span className="text-gray-400 normal-case font-medium">(optionnel)</span></label>
+            <textarea
+              value={form.description}
+              onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+              placeholder="Quantite approximative, depuis quand, contexte..."
+              className={`${inputClass} min-h-[80px] resize-y`}
+              maxLength={2000}
+            />
+          </div>
+
+          {error && <p className="text-sm font-bold text-red-600">{error}</p>}
+          {success && (
+            <div className="flex items-center gap-2 rounded-xl bg-emerald-50 px-4 py-3 text-sm font-bold text-emerald-700">
+              <CheckCircle2 className="h-4 w-4" />
+              Signalement envoye. L administratrice a ete notifiee.
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={sending || !form.titre.trim()}
+            className="inline-flex items-center gap-2 rounded-xl bg-[#e91e63] px-5 py-2.5 text-sm font-black text-white shadow-sm transition hover:bg-[#c41468] disabled:opacity-60"
+          >
+            <Send className="h-4 w-4" />
+            {sending ? 'Envoi...' : 'Envoyer le signalement'}
+          </button>
+        </form>
+      </section>
+
+      {/* Historique */}
+      <section className="rounded-xl border border-gray-100 bg-white p-5 shadow-sm">
+        <h2 className="mb-4 text-base font-black text-[#111018]">Mes signalements</h2>
+        {loading ? (
+          <p className="text-sm text-gray-400">Chargement...</p>
+        ) : signalements.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-gray-400">
+            <PackageSearch className="h-8 w-8" />
+            <p className="text-sm font-medium">Aucun signalement envoye pour l instant.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {signalements.map((s) => (
+              <div key={s.id} className={['rounded-xl border p-4', s.urgence === 'urgente' ? 'border-red-100 bg-red-50/40' : 'border-gray-100'].join(' ')}>
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {s.urgence === 'urgente' && <AlertTriangle className="h-4 w-4 shrink-0 text-red-500" />}
+                      <p className="font-black text-gray-950">{s.titre}</p>
+                    </div>
+                    <p className="mt-0.5 text-xs font-medium text-gray-400">
+                      {typeOptions.find((o) => o.value === s.type)?.label} · {formatDate(s.created_at)}
+                    </p>
+                    {s.description && <p className="mt-1 text-sm text-gray-600">{s.description}</p>}
+                    {s.note_admin && (
+                      <p className="mt-2 rounded-lg bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-800">
+                        <span className="font-black">Reponse admin :</span> {s.note_admin}
+                      </p>
+                    )}
+                  </div>
+                  <StatutBadge s={s} />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </GeranteLayout>
+  )
+}
+
+export default GeranteSignalementsPage

--- a/frontend/src/features/gerante/signalements.api.ts
+++ b/frontend/src/features/gerante/signalements.api.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '../../lib/apiClient'
+import type { Signalement, SignalementForm } from '../admin/signalements/signalements.types'
+
+type PaginatedResponse<T> = { data: { data: T[]; total: number; current_page: number; last_page: number } }
+
+export async function getGeranteSignalements() {
+  const response = await apiClient.get<PaginatedResponse<Signalement>>('/gerante/signalements')
+  return response.data.data
+}
+
+export async function createSignalement(form: SignalementForm) {
+  const response = await apiClient.post<{ message: string; data: Signalement }>('/gerante/signalements', form)
+  return response.data.data
+}

--- a/frontend/src/features/gerante/signalements.api.ts
+++ b/frontend/src/features/gerante/signalements.api.ts
@@ -5,7 +5,7 @@ type PaginatedResponse<T> = { data: { data: T[]; total: number; current_page: nu
 
 export async function getGeranteSignalements() {
   const response = await apiClient.get<PaginatedResponse<Signalement>>('/gerante/signalements')
-  return response.data.data
+  return response.data.data.data
 }
 
 export async function createSignalement(form: SignalementForm) {

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react'
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
 import {
   BarChart3,
+  Bell,
   BookOpen,
   CalendarDays,
   Camera,
@@ -27,6 +28,8 @@ import {
 } from 'lucide-react'
 import { clearAuth, getUser } from '../lib/authStorage'
 import { logout as apiLogout } from '../services/authService'
+import { getNonLusCount, getAdminSignalements, marquerLu, marquerTraite } from '../features/admin/signalements/signalements.api'
+import type { Signalement } from '../features/admin/signalements/signalements.types'
 
 type AdminLayoutProps = {
   children: ReactNode
@@ -75,6 +78,7 @@ const sections: Section[] = [
   { label: 'Messages WhatsApp', path: '/console-thomas/messages', icon: MessageCircle, comingSoon: true },
   { label: 'Photos prestations', path: '/console-thomas/photos', icon: Camera, comingSoon: true },
   { label: 'Rapports & Statistiques', path: '/console-thomas/rapports', icon: BarChart3 },
+  { label: 'Signalements', path: '/console-thomas/signalements', icon: Bell },
   { label: 'Logs systeme', path: '/console-thomas/logs', icon: ShoppingBag },
   { label: 'Parametres', path: '/console-thomas/parametres', icon: Settings },
 ]
@@ -90,6 +94,130 @@ function Brand() {
         <p className="font-display text-[24px] leading-5 text-white">Thomas</p>
         <p className="text-[11px] text-white/65">Salon de Coiffure</p>
       </div>
+    </div>
+  )
+}
+
+function NotifBell() {
+  const [count, setCount]         = useState(0)
+  const [open, setOpen]           = useState(false)
+  const [items, setItems]         = useState<Signalement[]>([])
+  const [noteMap, setNoteMap]     = useState<Record<number, string>>({})
+  const ref                       = useRef<HTMLDivElement>(null)
+
+  const loadCount = useCallback(async () => {
+    try { setCount(await getNonLusCount()) } catch { /* silencieux */ }
+  }, [])
+
+  const loadItems = useCallback(async () => {
+    try { setItems(await getAdminSignalements({ traite: false })) } catch { /* silencieux */ }
+  }, [])
+
+  // Polling toutes les 30s
+  useEffect(() => {
+    void loadCount()
+    const id = window.setInterval(() => void loadCount(), 30_000)
+    return () => window.clearInterval(id)
+  }, [loadCount])
+
+  // Fermer si clic en dehors
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  const toggle = () => {
+    setOpen((v) => {
+      if (!v) void loadItems()
+      return !v
+    })
+  }
+
+  const handleLu = async (s: Signalement) => {
+    if (s.lu_par_admin) return
+    const updated = await marquerLu(s.id)
+    setItems((prev) => prev.map((x) => (x.id === s.id ? updated : x)))
+    setCount((c) => Math.max(0, c - 1))
+  }
+
+  const handleTraite = async (s: Signalement) => {
+    const updated = await marquerTraite(s.id, noteMap[s.id] || undefined)
+    setItems((prev) => prev.filter((x) => x.id !== updated.id))
+    if (!s.lu_par_admin) setCount((c) => Math.max(0, c - 1))
+  }
+
+  const typeLabel = (t: string) => ({ produit: 'Produit', materiel: 'Materiel', autre: 'Autre' }[t] ?? t)
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={toggle}
+        className="relative flex h-9 w-9 items-center justify-center rounded-xl border border-gray-100 bg-white text-gray-700 shadow-sm hover:bg-gray-50"
+        aria-label="Notifications"
+      >
+        <Bell className="h-4.5 w-4.5 h-[18px] w-[18px]" />
+        {count > 0 && (
+          <span className="absolute -right-1 -top-1 flex h-4.5 h-[18px] w-[18px] items-center justify-center rounded-full bg-[#e91e63] text-[10px] font-black text-white">
+            {count > 9 ? '9+' : count}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-11 z-50 w-[340px] overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-2xl">
+          <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+            <p className="text-sm font-black text-gray-950">Signalements non traites</p>
+            <NavLink to="/console-thomas/signalements" onClick={() => setOpen(false)} className="text-xs font-bold text-[#e91e63] hover:underline">
+              Tout voir
+            </NavLink>
+          </div>
+          <div className="max-h-[400px] overflow-y-auto">
+            {items.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm font-medium text-gray-400">Aucun signalement en attente.</div>
+            ) : (
+              items.map((s) => (
+                <div
+                  key={s.id}
+                  className={['border-b border-gray-50 p-4 hover:bg-gray-50/50 cursor-pointer', !s.lu_par_admin ? 'bg-[#fff8fb]' : ''].join(' ')}
+                  onClick={() => void handleLu(s)}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        {!s.lu_par_admin && <span className="h-2 w-2 shrink-0 rounded-full bg-[#e91e63]" />}
+                        {s.urgence === 'urgente' && <span className="text-xs">🔴</span>}
+                        <p className="truncate text-sm font-black text-gray-900">{s.titre}</p>
+                      </div>
+                      <p className="mt-0.5 text-xs text-gray-400">{typeLabel(s.type)} · {s.gerante?.name}</p>
+                      {s.description && <p className="mt-1 line-clamp-2 text-xs text-gray-500">{s.description}</p>}
+                    </div>
+                  </div>
+                  <div className="mt-2 flex gap-2" onClick={(e) => e.stopPropagation()}>
+                    <input
+                      type="text"
+                      placeholder="Note (optionnel)..."
+                      value={noteMap[s.id] ?? ''}
+                      onChange={(e) => setNoteMap((m) => ({ ...m, [s.id]: e.target.value }))}
+                      className="min-w-0 flex-1 rounded-lg border border-gray-200 px-2 py-1 text-xs outline-none focus:border-[#e91e63]"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void handleTraite(s)}
+                      className="shrink-0 rounded-lg bg-emerald-500 px-2.5 py-1 text-xs font-black text-white hover:bg-emerald-600"
+                    >
+                      Traite
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -241,19 +369,27 @@ function AdminLayout({ children }: AdminLayoutProps) {
             <p className="text-[11px] font-semibold text-gray-500">Administration</p>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={() => setMobileMenuOpen(true)}
-          className="flex h-10 w-10 items-center justify-center rounded-xl border border-gray-100 bg-white text-gray-900 shadow-sm"
-          aria-label="Ouvrir le menu"
-        >
-          <Menu className="h-5 w-5" />
-        </button>
+        <div className="flex items-center gap-2">
+          <NotifBell />
+          <button
+            type="button"
+            onClick={() => setMobileMenuOpen(true)}
+            className="flex h-10 w-10 items-center justify-center rounded-xl border border-gray-100 bg-white text-gray-900 shadow-sm"
+            aria-label="Ouvrir le menu"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+        </div>
       </header>
 
       <aside className="fixed inset-y-0 left-0 z-30 hidden w-[252px] flex-col overflow-hidden bg-[#070711] px-3 py-3 text-white lg:flex">
         {renderNavigation()}
       </aside>
+
+      {/* Cloche desktop : coin supérieur droit */}
+      <div className="fixed right-4 top-4 z-20 hidden lg:block">
+        <NotifBell />
+      </div>
 
       {mobileMenuOpen && (
         <div className="fixed inset-0 z-40 lg:hidden">

--- a/frontend/src/layouts/GeranteLayout.tsx
+++ b/frontend/src/layouts/GeranteLayout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
-import { CalendarDays, CreditCard, LogOut, Menu, Users, X } from 'lucide-react'
+import { AlertTriangle, CalendarDays, CreditCard, LogOut, Menu, Users, X } from 'lucide-react'
 import { clearAuth, getUser } from '../lib/authStorage'
 import { logout as apiLogout } from '../services/authService'
 
@@ -93,6 +93,21 @@ function GeranteLayout({ children }: GeranteLayoutProps) {
         >
           <CreditCard className="h-4 w-4 shrink-0" />
           <span className="min-w-0 flex-1 truncate">Paiements</span>
+        </NavLink>
+        <NavLink
+          to="/manager/signalements"
+          onClick={closeMobileMenu}
+          className={({ isActive }) =>
+            [
+              'flex items-center gap-3 rounded-xl px-4 py-2 text-[13px] font-semibold transition',
+              isActive
+                ? 'bg-[#e91e63] text-white shadow-[0_14px_30px_-18px_rgba(233,30,99,0.9)]'
+                : 'text-white/85 hover:bg-white/8 hover:text-white',
+            ].join(' ')
+          }
+        >
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">Signalements</span>
         </NavLink>
       </nav>
 

--- a/infra/scripts/k6-load-test.js
+++ b/infra/scripts/k6-load-test.js
@@ -165,9 +165,9 @@ export function navigation() {
 // L'important est de mesurer le temps de réponse de l'endpoint sous charge.
 
 const NUMEROS_TEST = [
-  '+221771111111',
-  '+221782222222',
-  '+221703333333',
+  '+221771397393',
+  '+221777231600',
+  '+221765923402',
   '+221774444444',
   '+221785555555',
 ]


### PR DESCRIPTION
…he de notification

Backend :
- Migration + modele Signalement (type, titre, description, urgence, lu_par_admin, traite)
- Job SendSignalementNotification : WhatsApp + Email admin a chaque signalement
- Mail SignalementAdminMail + template blade
- Controller gerante : creer + lister ses signalements
- Controller admin : lister, compter non lus, marquer lu, marquer traite
- 6 nouvelles routes (3 admin, 2 gerante)

Frontend :
- Cloche de notification dans AdminLayout avec badge rouge + polling 30s
- Dropdown inline : marquer traite avec note depuis la cloche sans quitter la page
- Page admin /console-thomas/signalements avec filtre non-traites/traites/tous
- Page gerante /manager/signalements : formulaire d envoi + historique
- Lien Signalements dans la nav gerante