### PR TITLE
feat(galerie): galerie d'accueil geree par l'admin (max 10 photos)

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/GaleriePhotoController.php
+++ b/backend/app/Http/Controllers/Api/Admin/GaleriePhotoController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\GaleriePhoto;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\ImageManager;
+
+class GaleriePhotoController extends Controller
+{
+    /** Nombre maximum de photos dans la galerie d'accueil. */
+    private const MAX_PHOTOS = 10;
+
+    public function index(): JsonResponse
+    {
+        return response()->json([
+            'data' => GaleriePhoto::query()
+                ->orderBy('ordre')
+                ->orderBy('id')
+                ->get(),
+            'max' => self::MAX_PHOTOS,
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        // Refuse l'upload si la galerie est deja pleine (limite produit : 10).
+        if (GaleriePhoto::query()->count() >= self::MAX_PHOTOS) {
+            return response()->json([
+                'message' => 'La galerie est limitee a ' . self::MAX_PHOTOS . ' photos. Supprimez-en une avant d en ajouter.',
+            ], 422);
+        }
+
+        $data = $request->validate([
+            'image' => ['required', 'image', 'max:4096'],
+            'titre' => ['nullable', 'string', 'max:255'],
+            'sous_titre' => ['nullable', 'string', 'max:255'],
+            'actif' => ['sometimes', 'boolean'],
+        ]);
+
+        $url = $this->processAndStore($request->file('image'), 'galerie', 1200, 1600);
+        $nextOrdre = (int) GaleriePhoto::query()->max('ordre') + 1;
+
+        $photo = GaleriePhoto::query()->create([
+            'url' => $url,
+            'titre' => $data['titre'] ?? null,
+            'sous_titre' => $data['sous_titre'] ?? null,
+            'ordre' => $nextOrdre,
+            'actif' => $data['actif'] ?? true,
+        ]);
+
+        return response()->json([
+            'message' => 'Photo ajoutee a la galerie.',
+            'data' => $photo,
+        ], 201);
+    }
+
+    public function update(Request $request, GaleriePhoto $galeriePhoto): JsonResponse
+    {
+        $data = $request->validate([
+            'image' => ['nullable', 'image', 'max:4096'],
+            'titre' => ['nullable', 'string', 'max:255'],
+            'sous_titre' => ['nullable', 'string', 'max:255'],
+            'ordre' => ['sometimes', 'integer', 'min:0'],
+            'actif' => ['sometimes', 'boolean'],
+        ]);
+
+        if ($request->hasFile('image')) {
+            $this->deleteStoredImage($galeriePhoto->url);
+            $data['image'] = null; // ne pas persister la cle "image"
+            $galeriePhoto->url = $this->processAndStore($request->file('image'), 'galerie', 1200, 1600);
+        }
+        unset($data['image']);
+
+        $galeriePhoto->fill($data)->save();
+
+        return response()->json([
+            'message' => 'Photo mise a jour.',
+            'data' => $galeriePhoto->refresh(),
+        ]);
+    }
+
+    public function destroy(GaleriePhoto $galeriePhoto): JsonResponse
+    {
+        // Supprime aussi le fichier du disque pour ne pas accumuler d orphelins.
+        $this->deleteStoredImage($galeriePhoto->url);
+        $galeriePhoto->delete();
+
+        return response()->json([
+            'message' => 'Photo supprimee.',
+        ]);
+    }
+
+    /**
+     * Redimensionne, convertit en WebP et stocke l'image (disque public).
+     * Retourne l'URL publique Laravel (/storage/...).
+     */
+    private function processAndStore(UploadedFile $file, string $directory, int $maxWidth, int $maxHeight): string
+    {
+        $manager = new ImageManager(new Driver());
+        $image = $manager->read($file->getRealPath());
+        $image->scaleDown(width: $maxWidth, height: $maxHeight);
+
+        $filename = Str::uuid() . '.webp';
+        $path = $directory . '/' . $filename;
+
+        Storage::disk('public')->put($path, $image->toWebp(quality: 85));
+
+        return Storage::url($path);
+    }
+
+    /**
+     * Supprime un fichier du disque public a partir de son URL /storage/...
+     */
+    private function deleteStoredImage(?string $url): void
+    {
+        if (! $url) {
+            return;
+        }
+
+        $path = ltrim(str_replace('/storage/', '', parse_url($url, PHP_URL_PATH) ?? $url), '/');
+
+        if ($path !== '' && Storage::disk('public')->exists($path)) {
+            Storage::disk('public')->delete($path);
+        }
+    }
+}

--- a/backend/app/Http/Controllers/Api/Client/CatalogueController.php
+++ b/backend/app/Http/Controllers/Api/Client/CatalogueController.php
@@ -8,6 +8,7 @@ use App\Models\CategorieCoiffure;
 use App\Models\Client;
 use App\Models\CodePromo;
 use App\Models\Coiffure;
+use App\Models\GaleriePhoto;
 use App\Models\Reservation;
 use App\Services\ClientResolver;
 use App\Support\PhoneNumber;
@@ -89,6 +90,7 @@ class CatalogueController extends Controller
             'categories' => $categories->values()->all(),
             'coiffures' => $coiffures->values()->all(),
             'promotions' => $this->activePromotions(),
+            'gallery' => $this->galleryPhotos(),
             'settings' => [
                 'devise' => SystemSettings::get('devise', 'FCFA'),
                 'telephone_whatsapp' => SystemSettings::get('telephone_whatsapp', '221778153939'),
@@ -413,6 +415,29 @@ class CatalogueController extends Controller
         }
 
         return $parts[0] . ' ' . mb_strtoupper(mb_substr($parts[1], 0, 1)) . '.';
+    }
+
+    /**
+     * Photos de la galerie d'accueil (actives uniquement), triees par ordre.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function galleryPhotos(): array
+    {
+        return GaleriePhoto::query()
+            ->where('actif', true)
+            ->orderBy('ordre')
+            ->orderBy('id')
+            ->limit(10)
+            ->get()
+            ->map(fn (GaleriePhoto $photo): array => [
+                'id' => $photo->id,
+                'url' => $photo->url,
+                'titre' => $photo->titre,
+                'sous_titre' => $photo->sous_titre,
+            ])
+            ->values()
+            ->all();
     }
 
     /**

--- a/backend/app/Models/GaleriePhoto.php
+++ b/backend/app/Models/GaleriePhoto.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['url', 'titre', 'sous_titre', 'ordre', 'actif'])]
+class GaleriePhoto extends Model
+{
+    use HasFactory;
+
+    protected $table = 'galerie_photos';
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'ordre' => 'integer',
+            'actif' => 'boolean',
+        ];
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Models\CategorieCoiffure;
 use App\Models\CodePromo;
 use App\Models\Coiffure;
+use App\Models\GaleriePhoto;
 use App\Observers\CatalogueObserver;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
@@ -38,5 +39,6 @@ class AppServiceProvider extends ServiceProvider
         Coiffure::observe(CatalogueObserver::class);
         CategorieCoiffure::observe(CatalogueObserver::class);
         CodePromo::observe(CatalogueObserver::class);
+        GaleriePhoto::observe(CatalogueObserver::class);
     }
 }

--- a/backend/database/migrations/2026_06_13_000001_create_galerie_photos_table.php
+++ b/backend/database/migrations/2026_06_13_000001_create_galerie_photos_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('galerie_photos', function (Blueprint $table): void {
+            $table->id();
+            $table->string('url');
+            $table->string('titre')->nullable();
+            $table->string('sous_titre')->nullable();
+            $table->unsignedInteger('ordre')->default(0);
+            $table->boolean('actif')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('galerie_photos');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Api\Admin\EvenementAnalyticsController;
 use App\Http\Controllers\Api\Admin\ExportJournalController;
 use App\Http\Controllers\Api\Admin\SignalementController as AdminSignalementController;
 use App\Http\Controllers\Api\Gerante\SignalementController as GeranteSignalementController;
+use App\Http\Controllers\Api\Admin\GaleriePhotoController;
 use App\Http\Controllers\Api\Admin\GeranteController;
 use App\Http\Controllers\Api\Admin\ImageCoiffureController;
 use App\Http\Controllers\Api\Gerante\ClientController as GeranteClientController;
@@ -117,6 +118,9 @@ Route::middleware(['auth.token', 'role:admin', 'log.admin'])
             ->parameters(['options-coiffures' => 'optionCoiffure']);
         Route::apiResource('images-coiffures', ImageCoiffureController::class)
             ->parameters(['images-coiffures' => 'imageCoiffure']);
+        Route::apiResource('galerie-photos', GaleriePhotoController::class)
+            ->only(['index', 'store', 'update', 'destroy'])
+            ->parameters(['galerie-photos' => 'galeriePhoto']);
         Route::apiResource('coiffeuses', CoiffeuseController::class)
             ->parameters(['coiffeuses' => 'coiffeuse']);
         Route::apiResource('gerantes', GeranteController::class)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ const CatalogueOverviewPage = lazy(() => import('./features/admin/catalogue/Cata
 const CategoriesCoiffuresPage = lazy(() => import('./features/admin/catalogue/CategoriesCoiffuresPage'))
 const CoiffuresPage = lazy(() => import('./features/admin/catalogue/CoiffuresPage'))
 const OptionsCoiffuresPage = lazy(() => import('./features/admin/catalogue/OptionsCoiffuresPage'))
+const GaleriePage = lazy(() => import('./features/admin/galerie/GaleriePage'))
 const VariantesCoiffuresPage = lazy(() => import('./features/admin/catalogue/VariantesCoiffuresPage'))
 const PersonnelOverviewPage = lazy(() => import('./features/admin/personnel/PersonnelOverviewPage'))
 const GerantesPage = lazy(() => import('./features/admin/personnel/GerantesPage'))
@@ -95,6 +96,7 @@ function App() {
       <Route path="/console-thomas/catalogue/coiffures" element={<AdminRoute><CoiffuresPage /></AdminRoute>} />
       <Route path="/console-thomas/catalogue/variantes" element={<AdminRoute><VariantesCoiffuresPage /></AdminRoute>} />
       <Route path="/console-thomas/catalogue/options" element={<AdminRoute><OptionsCoiffuresPage /></AdminRoute>} />
+      <Route path="/console-thomas/catalogue/galerie" element={<AdminRoute><GaleriePage /></AdminRoute>} />
       <Route path="/console-thomas/personnel" element={<AdminRoute><PersonnelOverviewPage /></AdminRoute>} />
       <Route path="/console-thomas/personnel/gerantes" element={<AdminRoute><GerantesPage /></AdminRoute>} />
       <Route path="/console-thomas/personnel/coiffeuses" element={<AdminRoute><CoiffeusesPage /></AdminRoute>} />

--- a/frontend/src/features/admin/catalogue/components/CatalogueLayout.tsx
+++ b/frontend/src/features/admin/catalogue/components/CatalogueLayout.tsx
@@ -7,6 +7,7 @@ const tabs = [
   { label: 'Categories', path: '/console-thomas/catalogue/categories-coiffures' },
   { label: 'Coiffures', path: '/console-thomas/catalogue/coiffures' },
   { label: 'Options', path: '/console-thomas/catalogue/options' },
+  { label: 'Galerie', path: '/console-thomas/catalogue/galerie' },
 ]
 
 type CatalogueLayoutProps = {

--- a/frontend/src/features/admin/galerie/GaleriePage.tsx
+++ b/frontend/src/features/admin/galerie/GaleriePage.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useState, type ChangeEvent } from 'react'
+import { Eye, EyeOff, Loader2, RefreshCw, Trash2, Upload } from 'lucide-react'
+import CatalogueLayout from '../catalogue/components/CatalogueLayout'
+import { EmptyState, ErrorState } from '../catalogue/components/CatalogueUi'
+import { inputClass, primaryButtonClass } from '../catalogue/components/catalogueUiTokens'
+import { createGaleriePhoto, deleteGaleriePhoto, getGaleriePhotos, updateGaleriePhoto } from './galerie.api'
+import type { GaleriePhoto } from './galerie.types'
+
+type Draft = { titre: string; sous_titre: string }
+
+function GaleriePage() {
+  const [photos, setPhotos] = useState<GaleriePhoto[]>([])
+  const [max, setMax] = useState(10)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [savingId, setSavingId] = useState<number | null>(null)
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+  const [drafts, setDrafts] = useState<Record<number, Draft>>({})
+
+  const load = useCallback(() => {
+    setLoading(true)
+    getGaleriePhotos()
+      .then((response) => {
+        setPhotos(response.data)
+        setMax(response.max)
+        setError(null)
+      })
+      .catch(() => setError('Impossible de charger la galerie.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const remaining = Math.max(0, max - photos.length)
+
+  const draftOf = (photo: GaleriePhoto): Draft =>
+    drafts[photo.id] ?? { titre: photo.titre ?? '', sous_titre: photo.sous_titre ?? '' }
+
+  const setDraft = (id: number, patch: Partial<Draft>, base: Draft) => {
+    setDrafts((current) => ({ ...current, [id]: { ...base, ...current[id], ...patch } }))
+  }
+
+  async function handleUpload(event: ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(event.target.files ?? []).slice(0, remaining)
+    event.target.value = ''
+    if (files.length === 0) {
+      return
+    }
+    setUploading(true)
+    setError(null)
+    try {
+      for (const file of files) {
+        await createGaleriePhoto({ image: file })
+      }
+      load()
+    } catch {
+      setError("Echec de l'upload. Formats image uniquement, 4 Mo max, 10 photos au total.")
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  async function handleSave(photo: GaleriePhoto) {
+    const draft = draftOf(photo)
+    setSavingId(photo.id)
+    setError(null)
+    try {
+      const updated = await updateGaleriePhoto(photo.id, { ...draft, actif: photo.actif })
+      setPhotos((current) => current.map((item) => (item.id === photo.id ? updated : item)))
+      setDrafts((current) => {
+        const next = { ...current }
+        delete next[photo.id]
+        return next
+      })
+    } catch {
+      setError('Enregistrement impossible.')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  async function handleToggleActif(photo: GaleriePhoto) {
+    const draft = draftOf(photo)
+    try {
+      const updated = await updateGaleriePhoto(photo.id, { ...draft, actif: !photo.actif })
+      setPhotos((current) => current.map((item) => (item.id === photo.id ? updated : item)))
+    } catch {
+      setError('Changement de visibilite impossible.')
+    }
+  }
+
+  async function handleDelete(photo: GaleriePhoto) {
+    if (!window.confirm('Supprimer cette photo de la galerie ?')) {
+      return
+    }
+    setDeletingId(photo.id)
+    try {
+      await deleteGaleriePhoto(photo.id)
+      setPhotos((current) => current.filter((item) => item.id !== photo.id))
+    } catch {
+      setError('Suppression impossible.')
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <CatalogueLayout
+      title="Galerie d'accueil"
+      subtitle="Les photos affichees dans la section « Le salon en images » de la page d'accueil (10 maximum)."
+      action={
+        <label
+          className={`${primaryButtonClass} inline-flex w-full cursor-pointer items-center justify-center gap-2 sm:w-auto ${
+            remaining === 0 || uploading ? 'cursor-not-allowed opacity-60' : ''
+          }`}
+        >
+          {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+          Ajouter des photos
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            disabled={remaining === 0 || uploading}
+            onChange={handleUpload}
+            className="sr-only"
+          />
+        </label>
+      }
+    >
+      <section className="mb-5 flex items-center justify-between gap-3 rounded-xl border border-gray-100 bg-white p-4 shadow-[0_18px_36px_-32px_rgba(20,20,43,0.5)]">
+        <p className="text-sm font-bold text-gray-500">
+          Les photos sont optimisees (WebP) et chargees a la demande : aucun impact notable sur les performances.
+        </p>
+        <span className="shrink-0 rounded-full bg-[#fff2f7] px-3 py-1 text-sm font-black text-[#c41468]">
+          {photos.length} / {max}
+        </span>
+      </section>
+
+      {error && <ErrorState label={error} />}
+
+      {loading ? (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-72 animate-pulse rounded-xl bg-gray-100" />
+          ))}
+        </div>
+      ) : photos.length === 0 ? (
+        <EmptyState label="Aucune photo pour le moment. Ajoutez-en jusqu'a 10 avec le bouton ci-dessus." />
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {photos.map((photo) => {
+            const draft = draftOf(photo)
+            const dirty = draft.titre !== (photo.titre ?? '') || draft.sous_titre !== (photo.sous_titre ?? '')
+
+            return (
+              <article
+                key={photo.id}
+                className={`overflow-hidden rounded-xl border bg-white shadow-sm transition ${
+                  photo.actif ? 'border-gray-100' : 'border-amber-200'
+                }`}
+              >
+                <div className="relative aspect-[4/5] overflow-hidden bg-[#fff2f7]">
+                  <img src={photo.url} alt={photo.titre ?? ''} className="h-full w-full object-cover" loading="lazy" />
+                  {!photo.actif && (
+                    <span className="absolute left-3 top-3 rounded-full bg-amber-500 px-2.5 py-1 text-[10px] font-black uppercase text-white">
+                      Masquee
+                    </span>
+                  )}
+                </div>
+                <div className="space-y-3 p-4">
+                  <input
+                    className={inputClass}
+                    placeholder="Titre (ex: Notre univers)"
+                    value={draft.titre}
+                    onChange={(event) => setDraft(photo.id, { titre: event.target.value }, { titre: photo.titre ?? '', sous_titre: photo.sous_titre ?? '' })}
+                  />
+                  <input
+                    className={inputClass}
+                    placeholder="Sous-titre (ex: Une ambiance chaleureuse)"
+                    value={draft.sous_titre}
+                    onChange={(event) => setDraft(photo.id, { sous_titre: event.target.value }, { titre: photo.titre ?? '', sous_titre: photo.sous_titre ?? '' })}
+                  />
+                  <div className="flex items-center justify-between gap-2 border-t border-gray-100 pt-3">
+                    <button
+                      type="button"
+                      onClick={() => void handleToggleActif(photo)}
+                      className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-xs font-black transition ${
+                        photo.actif ? 'text-emerald-700 hover:bg-emerald-50' : 'text-amber-700 hover:bg-amber-50'
+                      }`}
+                      title={photo.actif ? 'Visible sur le site' : 'Masquee'}
+                    >
+                      {photo.actif ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                      {photo.actif ? 'Visible' : 'Masquee'}
+                    </button>
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => void handleSave(photo)}
+                        disabled={!dirty || savingId === photo.id}
+                        className="inline-flex items-center gap-1.5 rounded-lg bg-[#e91e63] px-3 py-2 text-xs font-black text-white transition hover:bg-[#c41468] disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        {savingId === photo.id ? <RefreshCw className="h-4 w-4 animate-spin" /> : null}
+                        Enregistrer
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleDelete(photo)}
+                        disabled={deletingId === photo.id}
+                        className="rounded-lg p-2 text-red-600 transition hover:bg-red-50 disabled:opacity-40"
+                        title="Supprimer"
+                      >
+                        {deletingId === photo.id ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </CatalogueLayout>
+  )
+}
+
+export default GaleriePage

--- a/frontend/src/features/admin/galerie/galerie.api.ts
+++ b/frontend/src/features/admin/galerie/galerie.api.ts
@@ -1,0 +1,44 @@
+import { apiClient } from '../../../lib/apiClient'
+import { apiAssetUrl } from '../../../lib/apiAssets'
+import type { GaleriePhoto } from './galerie.types'
+
+type IndexResponse = { data: GaleriePhoto[]; max: number }
+type ItemResponse = { message?: string; data: GaleriePhoto }
+
+function normalize(photo: GaleriePhoto): GaleriePhoto {
+  return { ...photo, url: apiAssetUrl(photo.url) ?? photo.url }
+}
+
+export async function getGaleriePhotos() {
+  const response = await apiClient.get<IndexResponse>('/admin/galerie-photos')
+  return { max: response.data.max, data: response.data.data.map(normalize) }
+}
+
+export async function createGaleriePhoto(input: { image: File; titre?: string; sous_titre?: string }) {
+  const formData = new FormData()
+  formData.append('image', input.image)
+  if (input.titre) {
+    formData.append('titre', input.titre)
+  }
+  if (input.sous_titre) {
+    formData.append('sous_titre', input.sous_titre)
+  }
+  const response = await apiClient.post<ItemResponse>('/admin/galerie-photos', formData)
+  return normalize(response.data.data)
+}
+
+export async function updateGaleriePhoto(
+  id: number,
+  input: { titre: string; sous_titre: string; actif: boolean },
+) {
+  const response = await apiClient.put<ItemResponse>(`/admin/galerie-photos/${id}`, {
+    titre: input.titre.trim() === '' ? null : input.titre.trim(),
+    sous_titre: input.sous_titre.trim() === '' ? null : input.sous_titre.trim(),
+    actif: input.actif,
+  })
+  return normalize(response.data.data)
+}
+
+export async function deleteGaleriePhoto(id: number) {
+  await apiClient.delete(`/admin/galerie-photos/${id}`)
+}

--- a/frontend/src/features/admin/galerie/galerie.types.ts
+++ b/frontend/src/features/admin/galerie/galerie.types.ts
@@ -1,0 +1,8 @@
+export type GaleriePhoto = {
+  id: number
+  url: string
+  titre: string | null
+  sous_titre: string | null
+  ordre: number
+  actif: boolean
+}

--- a/frontend/src/features/client/ClientHomePage.tsx
+++ b/frontend/src/features/client/ClientHomePage.tsx
@@ -389,25 +389,36 @@ function ClientHomePage() {
     return () => observer.disconnect()
   }, [loading])
 
+  // Galerie : photos de la base (gerees par l'admin). Si aucune n'est encore
+  // uploadee, on retombe sur les 3 visuels statiques pour ne pas laisser la
+  // section vide.
+  const galleryItems = useMemo(() => {
+    const fromDb = (catalogue?.gallery ?? []).map((photo) => ({
+      src: photo.url,
+      titre: photo.titre ?? 'Bichette Thomas',
+      sousTitre: photo.sous_titre ?? '',
+    }))
+    return fromDb.length > 0 ? fromDb : salonGallery
+  }, [catalogue?.gallery])
+
   // Navigation clavier de la lightbox galerie (Echap, fleches gauche/droite).
   useEffect(() => {
     if (lightboxIndex === null) {
       return
     }
+    const count = galleryItems.length
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setLightboxIndex(null)
       } else if (event.key === 'ArrowRight') {
-        setLightboxIndex((current) => (current === null ? current : (current + 1) % salonGallery.length))
+        setLightboxIndex((current) => (current === null ? current : (current + 1) % count))
       } else if (event.key === 'ArrowLeft') {
-        setLightboxIndex((current) =>
-          current === null ? current : (current - 1 + salonGallery.length) % salonGallery.length,
-        )
+        setLightboxIndex((current) => (current === null ? current : (current - 1 + count) % count))
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [lightboxIndex])
+  }, [lightboxIndex, galleryItems])
 
   const categories = catalogue?.categories ?? emptyCategories
   const coiffures = catalogue?.coiffures ?? emptyCoiffures
@@ -1056,27 +1067,27 @@ function ClientHomePage() {
               </p>
             </Reveal>
 
-            <div className="mt-9 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {salonGallery.map((item, index) => (
+            {/* Mosaique masonry (colonnes CSS) : hauteurs variables = rendu
+                dynamique facon mur de photos. Jusqu'a 10 visuels geres en admin. */}
+            <div className="mt-9 columns-2 gap-4 sm:columns-3 lg:columns-4">
+              {galleryItems.map((item, index) => (
                 <Reveal
-                  key={item.src}
-                  delay={index * 140}
-                  className={`group relative overflow-hidden rounded-3xl bg-[#fff0f6] shadow-sm ${
-                    index === 1 ? 'sm:col-span-2 lg:col-span-1' : ''
-                  }`}
+                  key={`${item.src}-${index}`}
+                  delay={Math.min(index * 90, 540)}
+                  className="group relative mb-4 block break-inside-avoid overflow-hidden rounded-3xl bg-[#fff0f6] shadow-sm transition-shadow duration-500 hover:shadow-[0_26px_46px_-24px_rgba(243,25,118,0.55)]"
                 >
                   <img
                     src={item.src}
                     alt={item.titre}
-                    className="aspect-[3/4] w-full object-cover object-top transition duration-[1100ms] ease-out group-hover:scale-110"
+                    className="w-full transition duration-[1100ms] ease-out group-hover:scale-110"
                     loading="lazy"
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent" />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/5 to-transparent opacity-90 transition duration-500 group-hover:opacity-100" />
                   <div className="absolute inset-x-0 bottom-0 translate-y-2 p-5 opacity-0 transition duration-500 group-hover:translate-y-0 group-hover:opacity-100">
                     <p className="text-[10px] font-black uppercase tracking-[0.24em] text-white/80">{item.titre}</p>
-                    <p className="mt-1 text-lg font-black leading-snug text-white">{item.sousTitre}</p>
+                    {item.sousTitre ? <p className="mt-1 text-lg font-black leading-snug text-white">{item.sousTitre}</p> : null}
                   </div>
-                  <span className="absolute left-4 top-4 grid h-9 w-9 place-items-center rounded-full bg-white/90 text-[#f31976] shadow-sm">
+                  <span className="absolute left-4 top-4 grid h-9 w-9 place-items-center rounded-full bg-white/90 text-[#f31976] shadow-sm transition duration-500 group-hover:scale-110 group-hover:rotate-12">
                     <Sparkles className="h-4 w-4" />
                   </span>
                   <button
@@ -1382,7 +1393,7 @@ function ClientHomePage() {
             onClick={(event) => {
               event.stopPropagation()
               setLightboxIndex((current) =>
-                current === null ? current : (current - 1 + salonGallery.length) % salonGallery.length,
+                current === null ? current : (current - 1 + galleryItems.length) % galleryItems.length,
               )
             }}
             aria-label="Photo precedente"
@@ -1393,22 +1404,24 @@ function ClientHomePage() {
           <figure className="flex max-h-[88vh] max-w-3xl flex-col items-center" onClick={(event) => event.stopPropagation()}>
             <img
               key={lightboxIndex}
-              src={salonGallery[lightboxIndex].src}
-              alt={salonGallery[lightboxIndex].titre}
+              src={galleryItems[lightboxIndex].src}
+              alt={galleryItems[lightboxIndex].titre}
               className="bt-zoom-in max-h-[80vh] w-auto max-w-full rounded-2xl object-contain shadow-2xl"
             />
             <figcaption className="mt-4 text-center">
               <p className="text-[10px] font-black uppercase tracking-[0.24em] text-white/70">
-                {salonGallery[lightboxIndex].titre}
+                {galleryItems[lightboxIndex].titre}
               </p>
-              <p className="mt-1 text-sm font-bold text-white">{salonGallery[lightboxIndex].sousTitre}</p>
+              {galleryItems[lightboxIndex].sousTitre ? (
+                <p className="mt-1 text-sm font-bold text-white">{galleryItems[lightboxIndex].sousTitre}</p>
+              ) : null}
             </figcaption>
           </figure>
           <button
             type="button"
             onClick={(event) => {
               event.stopPropagation()
-              setLightboxIndex((current) => (current === null ? current : (current + 1) % salonGallery.length))
+              setLightboxIndex((current) => (current === null ? current : (current + 1) % galleryItems.length))
             }}
             aria-label="Photo suivante"
             className="absolute right-3 grid h-11 w-11 place-items-center rounded-full bg-white/15 text-white transition hover:bg-white/25 sm:right-6"

--- a/frontend/src/features/client/client.api.ts
+++ b/frontend/src/features/client/client.api.ts
@@ -58,6 +58,10 @@ function normalizeCatalogue(catalogue: ClientCatalogue): ClientCatalogue {
     ...catalogue,
     categories: catalogue.categories.map(normalizeCategory),
     coiffures: catalogue.coiffures.map(normalizeCoiffure),
+    gallery: (catalogue.gallery ?? []).map((photo) => ({
+      ...photo,
+      url: apiAssetUrl(photo.url) ?? photo.url,
+    })),
   }
 }
 

--- a/frontend/src/features/client/client.types.ts
+++ b/frontend/src/features/client/client.types.ts
@@ -125,10 +125,18 @@ export type ClientSettings = {
   }
 }
 
+export type ClientGalleryPhoto = {
+  id: number
+  url: string
+  titre: string | null
+  sous_titre: string | null
+}
+
 export type ClientCatalogue = {
   categories: ClientCategory[]
   coiffures: ClientCoiffure[]
   promotions: ClientPromotion[]
+  gallery: ClientGalleryPhoto[]
   settings: ClientSettings
 }
 

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -58,6 +58,7 @@ const sections: Section[] = [
       { label: 'Categories coiffures', path: '/console-thomas/catalogue/categories-coiffures' },
       { label: 'Coiffures', path: '/console-thomas/catalogue/coiffures' },
       { label: 'Options', path: '/console-thomas/catalogue/options' },
+      { label: 'Galerie accueil', path: '/console-thomas/catalogue/galerie' },
     ],
   },
   {


### PR DESCRIPTION
Backend :
- table galerie_photos (url, titre, sous_titre, ordre, actif) + modele
- GaleriePhotoController admin : upload (WebP + resize, max 10), CRUD, suppression du fichier disque, observer cache catalogue
- exposition dans le catalogue public (cle "gallery")

Frontend client :
- la section galerie lit la base (fallback statique si vide)
- mosaique masonry dynamique (colonnes CSS, hauteurs variables) + reveal en cascade, survol zoom/ombre, lightbox clavier ; images lazy-loaded

Frontend admin :
- page "Galerie accueil" (onglet Catalogue) : upload jusqu'a 10, legendes editables, visible/masquee, suppression

Perf : photos converties en WebP + lazy-loading -> impact negligeable.