### PR TITLE
feat(accueil): image de garde (hero) modifiable par l'admin

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/ImageAccueilController.php
+++ b/backend/app/Http/Controllers/Api/Admin/ImageAccueilController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ParametreSysteme;
+use App\Support\SystemSettings;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\ImageManager;
+
+/**
+ * Gestion de l'image de garde (hero) de la page d'accueil.
+ *
+ * Stockee comme parametre systeme "image_accueil" (URL /storage/...), elle est
+ * exposee dans /client/catalogue. Si vide, le front retombe sur le visuel par
+ * defaut. L'admin peut donc changer l'image d'accueil a tout moment.
+ */
+class ImageAccueilController extends Controller
+{
+    private const KEY = 'image_accueil';
+
+    public function show(): JsonResponse
+    {
+        return response()->json(['url' => SystemSettings::get(self::KEY)]);
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $request->validate([
+            'image' => ['required', 'image', 'max:8192'],
+        ]);
+
+        $this->deleteStoredImage(SystemSettings::get(self::KEY));
+        $url = $this->processAndStore($request->file('image'), 'accueil', 1920, 1280);
+        $this->persist($url);
+
+        return response()->json([
+            'message' => 'Image de garde mise a jour.',
+            'url' => $url,
+        ]);
+    }
+
+    public function destroy(): JsonResponse
+    {
+        $this->deleteStoredImage(SystemSettings::get(self::KEY));
+        $this->persist(null);
+
+        return response()->json([
+            'message' => 'Image de garde reinitialisee.',
+            'url' => null,
+        ]);
+    }
+
+    private function persist(?string $url): void
+    {
+        ParametreSysteme::query()->updateOrCreate(
+            ['cle' => self::KEY],
+            [
+                'valeur' => ['value' => $url],
+                'type' => 'string',
+                'description' => "Image de garde (hero) de la page d'accueil.",
+                'modifiable' => false,
+            ],
+        );
+
+        // La valeur est exposee dans le catalogue public (cache 5 min) : on
+        // invalide pour que le changement soit visible immediatement.
+        Cache::increment('catalogue:cache:version');
+    }
+
+    private function processAndStore(UploadedFile $file, string $directory, int $maxWidth, int $maxHeight): string
+    {
+        $manager = new ImageManager(new Driver());
+        $image = $manager->read($file->getRealPath());
+        $image->scaleDown(width: $maxWidth, height: $maxHeight);
+
+        $filename = Str::uuid() . '.webp';
+        $path = $directory . '/' . $filename;
+
+        Storage::disk('public')->put($path, $image->toWebp(quality: 85));
+
+        return Storage::url($path);
+    }
+
+    private function deleteStoredImage(?string $url): void
+    {
+        if (! $url) {
+            return;
+        }
+
+        $path = ltrim(str_replace('/storage/', '', parse_url($url, PHP_URL_PATH) ?? $url), '/');
+
+        if ($path !== '' && Storage::disk('public')->exists($path)) {
+            Storage::disk('public')->delete($path);
+        }
+    }
+}

--- a/backend/app/Http/Controllers/Api/Client/CatalogueController.php
+++ b/backend/app/Http/Controllers/Api/Client/CatalogueController.php
@@ -93,6 +93,7 @@ class CatalogueController extends Controller
             'gallery' => $this->galleryPhotos(),
             'settings' => [
                 'devise' => SystemSettings::get('devise', 'FCFA'),
+                'image_accueil' => SystemSettings::get('image_accueil'),
                 'telephone_whatsapp' => SystemSettings::get('telephone_whatsapp', '221778153939'),
                 'heure_ouverture' => SystemSettings::get('heure_ouverture', '09:00'),
                 'heure_fermeture' => SystemSettings::get('heure_fermeture', '19:00'),

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\Admin\SignalementController as AdminSignalementCont
 use App\Http\Controllers\Api\Gerante\SignalementController as GeranteSignalementController;
 use App\Http\Controllers\Api\Admin\GaleriePhotoController;
 use App\Http\Controllers\Api\Admin\GeranteController;
+use App\Http\Controllers\Api\Admin\ImageAccueilController;
 use App\Http\Controllers\Api\Admin\ImageCoiffureController;
 use App\Http\Controllers\Api\Gerante\ClientController as GeranteClientController;
 use App\Http\Controllers\Api\Gerante\PaiementController as GerantePaiementController;
@@ -125,6 +126,9 @@ Route::middleware(['auth.token', 'role:admin', 'log.admin'])
             ->parameters(['coiffeuses' => 'coiffeuse']);
         Route::apiResource('gerantes', GeranteController::class)
             ->parameters(['gerantes' => 'gerante']);
+        Route::get('parametres/image-accueil', [ImageAccueilController::class, 'show'])->name('parametres.image-accueil.show');
+        Route::post('parametres/image-accueil', [ImageAccueilController::class, 'update'])->name('parametres.image-accueil.update');
+        Route::delete('parametres/image-accueil', [ImageAccueilController::class, 'destroy'])->name('parametres.image-accueil.destroy');
         Route::apiResource('parametres-systeme', ParametreSystemeController::class)
             ->parameters(['parametres-systeme' => 'parametreSysteme']);
         Route::apiResource('regles-fidelite', RegleFideliteController::class)

--- a/frontend/src/features/admin/galerie/GaleriePage.tsx
+++ b/frontend/src/features/admin/galerie/GaleriePage.tsx
@@ -1,9 +1,17 @@
 import { useCallback, useEffect, useState, type ChangeEvent } from 'react'
-import { Eye, EyeOff, Loader2, RefreshCw, Trash2, Upload } from 'lucide-react'
+import { Eye, EyeOff, Image as ImageIcon, Loader2, RefreshCw, Trash2, Upload } from 'lucide-react'
 import CatalogueLayout from '../catalogue/components/CatalogueLayout'
 import { EmptyState, ErrorState } from '../catalogue/components/CatalogueUi'
-import { inputClass, primaryButtonClass } from '../catalogue/components/catalogueUiTokens'
-import { createGaleriePhoto, deleteGaleriePhoto, getGaleriePhotos, updateGaleriePhoto } from './galerie.api'
+import { inputClass, primaryButtonClass, secondaryButtonClass } from '../catalogue/components/catalogueUiTokens'
+import {
+  createGaleriePhoto,
+  deleteGaleriePhoto,
+  getGaleriePhotos,
+  getImageAccueil,
+  removeImageAccueil,
+  updateGaleriePhoto,
+  uploadImageAccueil,
+} from './galerie.api'
 import type { GaleriePhoto } from './galerie.types'
 
 type Draft = { titre: string; sous_titre: string }
@@ -17,6 +25,8 @@ function GaleriePage() {
   const [savingId, setSavingId] = useState<number | null>(null)
   const [deletingId, setDeletingId] = useState<number | null>(null)
   const [drafts, setDrafts] = useState<Record<number, Draft>>({})
+  const [heroImage, setHeroImage] = useState<string | null>(null)
+  const [heroBusy, setHeroBusy] = useState(false)
 
   const load = useCallback(() => {
     setLoading(true)
@@ -34,7 +44,45 @@ function GaleriePage() {
     load()
   }, [load])
 
+  useEffect(() => {
+    getImageAccueil()
+      .then(setHeroImage)
+      .catch(() => {})
+  }, [])
+
   const remaining = Math.max(0, max - photos.length)
+
+  async function handleHeroUpload(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) {
+      return
+    }
+    setHeroBusy(true)
+    setError(null)
+    try {
+      setHeroImage(await uploadImageAccueil(file))
+    } catch {
+      setError("Echec de l'upload de l'image de garde. Formats image, 8 Mo max.")
+    } finally {
+      setHeroBusy(false)
+    }
+  }
+
+  async function handleHeroRemove() {
+    if (!window.confirm("Reinitialiser l'image de garde (revenir au visuel par defaut) ?")) {
+      return
+    }
+    setHeroBusy(true)
+    try {
+      await removeImageAccueil()
+      setHeroImage(null)
+    } catch {
+      setError("Reinitialisation impossible.")
+    } finally {
+      setHeroBusy(false)
+    }
+  }
 
   const draftOf = (photo: GaleriePhoto): Draft =>
     drafts[photo.id] ?? { titre: photo.titre ?? '', sous_titre: photo.sous_titre ?? '' }
@@ -130,6 +178,41 @@ function GaleriePage() {
         </label>
       }
     >
+      {/* Image de garde (hero) de la page d'accueil. */}
+      <section className="mb-5 rounded-xl border border-gray-100 bg-white p-4 shadow-[0_18px_36px_-32px_rgba(20,20,43,0.5)]">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <div className="relative aspect-video w-full shrink-0 overflow-hidden rounded-lg bg-[#fff2f7] sm:w-72">
+            {heroImage ? (
+              <img src={heroImage} alt="Image de garde" className="h-full w-full object-cover" />
+            ) : (
+              <div className="grid h-full place-items-center text-[#e91e63]/45">
+                <ImageIcon className="h-10 w-10" />
+              </div>
+            )}
+          </div>
+          <div className="flex-1">
+            <h3 className="text-lg font-black text-gray-900">Image de garde (accueil)</h3>
+            <p className="mt-1 text-sm font-medium text-gray-500">
+              La grande image en haut de la page d'accueil. {heroImage ? 'Vous pouvez la changer a tout moment.' : 'Par defaut : le visuel/video fourni.'}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <label
+                className={`${primaryButtonClass} inline-flex cursor-pointer items-center gap-2 ${heroBusy ? 'cursor-not-allowed opacity-60' : ''}`}
+              >
+                {heroBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                {heroImage ? "Changer l'image" : "Definir l'image"}
+                <input type="file" accept="image/*" disabled={heroBusy} onChange={handleHeroUpload} className="sr-only" />
+              </label>
+              {heroImage ? (
+                <button type="button" onClick={() => void handleHeroRemove()} disabled={heroBusy} className={secondaryButtonClass}>
+                  Reinitialiser
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section className="mb-5 flex items-center justify-between gap-3 rounded-xl border border-gray-100 bg-white p-4 shadow-[0_18px_36px_-32px_rgba(20,20,43,0.5)]">
         <p className="text-sm font-bold text-gray-500">
           Les photos sont optimisees (WebP) et chargees a la demande : aucun impact notable sur les performances.

--- a/frontend/src/features/admin/galerie/galerie.api.ts
+++ b/frontend/src/features/admin/galerie/galerie.api.ts
@@ -42,3 +42,21 @@ export async function updateGaleriePhoto(
 export async function deleteGaleriePhoto(id: number) {
   await apiClient.delete(`/admin/galerie-photos/${id}`)
 }
+
+// --- Image de garde (hero) de la page d'accueil ---------------------------
+
+export async function getImageAccueil(): Promise<string | null> {
+  const response = await apiClient.get<{ url: string | null }>('/admin/parametres/image-accueil')
+  return apiAssetUrl(response.data.url)
+}
+
+export async function uploadImageAccueil(image: File): Promise<string | null> {
+  const formData = new FormData()
+  formData.append('image', image)
+  const response = await apiClient.post<{ url: string | null }>('/admin/parametres/image-accueil', formData)
+  return apiAssetUrl(response.data.url)
+}
+
+export async function removeImageAccueil(): Promise<void> {
+  await apiClient.delete('/admin/parametres/image-accueil')
+}

--- a/frontend/src/features/client/ClientHomePage.tsx
+++ b/frontend/src/features/client/ClientHomePage.tsx
@@ -780,21 +780,32 @@ function ClientHomePage() {
 
       <section className="relative overflow-hidden bg-[#f31976] text-white">
             <div className="absolute inset-0">
-              <video
-                className="hidden h-full w-full object-cover object-center md:block"
-                src="/video acceuil.MP4"
-                autoPlay
-                muted
-                loop
-                playsInline
-                preload="metadata"
-              />
-              <img
-                src="/image mobile.jpg"
-                alt=""
-                className="bt-kenburns h-full w-full object-cover object-[55%_center] opacity-90 md:hidden"
-                loading="lazy"
-              />
+              {settings?.image_accueil ? (
+                // Image de garde definie par l'admin : prioritaire sur la video.
+                <img
+                  src={settings.image_accueil}
+                  alt=""
+                  className="bt-kenburns h-full w-full object-cover object-center opacity-95"
+                />
+              ) : (
+                <>
+                  <video
+                    className="hidden h-full w-full object-cover object-center md:block"
+                    src="/video acceuil.MP4"
+                    autoPlay
+                    muted
+                    loop
+                    playsInline
+                    preload="metadata"
+                  />
+                  <img
+                    src="/image mobile.jpg"
+                    alt=""
+                    className="bt-kenburns h-full w-full object-cover object-[55%_center] opacity-90 md:hidden"
+                    loading="lazy"
+                  />
+                </>
+              )}
               <div className="absolute inset-0 hidden bg-gradient-to-r from-black/60 via-[#f31976]/15 to-transparent md:block" />
               <div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/20 to-transparent md:hidden" />
             </div>

--- a/frontend/src/features/client/client.api.ts
+++ b/frontend/src/features/client/client.api.ts
@@ -62,6 +62,10 @@ function normalizeCatalogue(catalogue: ClientCatalogue): ClientCatalogue {
       ...photo,
       url: apiAssetUrl(photo.url) ?? photo.url,
     })),
+    settings: {
+      ...catalogue.settings,
+      image_accueil: apiAssetUrl(catalogue.settings.image_accueil),
+    },
   }
 }
 

--- a/frontend/src/features/client/client.types.ts
+++ b/frontend/src/features/client/client.types.ts
@@ -110,6 +110,7 @@ export type ClientPromotion = {
 
 export type ClientSettings = {
   devise: 'FCFA' | string
+  image_accueil: string | null
   telephone_whatsapp: string | null
   heure_ouverture: string
   heure_fermeture: string

--- a/frontend/src/features/client/components/ReservationModal.test.tsx
+++ b/frontend/src/features/client/components/ReservationModal.test.tsx
@@ -51,6 +51,7 @@ function makeCoiffure(): ClientCoiffure {
 function makeSettings(): ClientSettings {
   return {
     devise: 'FCFA',
+    image_accueil: null,
     telephone_whatsapp: '+221770000000',
     heure_ouverture: '09:00',
     heure_fermeture: '19:00',


### PR DESCRIPTION
L'admin peut definir/changer a tout moment la grande image d'accueil, au lieu du visuel code en dur.

Backend :
- ImageAccueilController : upload (WebP + resize 1920x1280), reset, lecture ; stocke l'URL dans le parametre systeme "image_accueil" + invalide le cache catalogue. Routes /admin/parametres/image-accueil (GET/POST/DELETE).
- expose "image_accueil" dans les settings du catalogue public.

Frontend :
- hero : si une image de garde est definie, elle remplace la video/visuel par defaut (sinon comportement inchange).
- admin (page Galerie) : section "Image de garde" avec apercu, changer, reset.

Pas de migration (reutilise parametres_systeme). Image optimisee + lazy.