### PR TITLE
fix(spa): corrige "Importing a module script failed" apres deploiement

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,20 @@ import { initSentry } from './lib/sentry'
 // Capture des erreurs front (no-op si aucun VITE_SENTRY_DSN n'est defini).
 initSentry()
 
+// Recuperation auto apres un deploiement : si un chunk lazy ne peut pas se
+// charger (souvent parce que la page etait ouverte pendant un deploiement et
+// reference d'anciens fichiers hashes), Vite emet "vite:preloadError". On
+// recharge alors la page pour recuperer la derniere version. Garde-fou
+// temporel : au plus un rechargement / 10 s, pour eviter toute boucle si
+// l'echec est reel (reseau, chunk reellement manquant).
+window.addEventListener('vite:preloadError', () => {
+  const lastReload = Number(sessionStorage.getItem('bt-preload-reload-at') ?? 0)
+  if (Date.now() - lastReload > 10_000) {
+    sessionStorage.setItem('bt-preload-reload-at', String(Date.now()))
+    window.location.reload()
+  }
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>

--- a/infra/docker/nginx/prod.conf
+++ b/infra/docker/nginx/prod.conf
@@ -99,9 +99,19 @@ server {
         add_header Cache-Control "public, max-age=3600" always;
     }
 
+    # ── index.html : JAMAIS mis en cache ──────────────────────────────────────
+    # index.html reference les chunks JS hashes. S'il est cache, le navigateur
+    # garde d'anciennes references apres un deploiement et echoue a charger les
+    # nouveaux chunks ("Importing a module script failed"). On force donc une
+    # revalidation a chaque fois (le fichier est minuscule).
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+    }
+
     # ── SPA React (fallback) ──────────────────────────────────────────────────
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache, must-revalidate" always;
     }
 
     # Bloquer les fichiers cachés (.env, .git, etc.)


### PR DESCRIPTION
Cause : index.html n'avait aucun en-tete de cache -> le navigateur gardait d'anciennes references de chunks hashes apres un deploiement, et l'import des nouveaux chunks lazy echouait (erreur remontee par Sentry, surtout iOS).

- nginx (prod.conf) : index.html servi en "no-cache, must-revalidate" pour que les references de chunks soient toujours fraiches (les assets hashes restent immutable/1 an).
- front (main.tsx) : ecoute "vite:preloadError" -> recharge la page une fois (garde-fou : max 1 reload / 10 s) pour les sessions ouvertes pendant un deploiement.