### PR TITLE
fix(boutique): paiement NabooPay en ligne (405) + droits storage prod

### DIFF
--- a/backend/app/Http/Controllers/Api/Client/BoutiqueCommandeController.php
+++ b/backend/app/Http/Controllers/Api/Client/BoutiqueCommandeController.php
@@ -283,18 +283,21 @@ class BoutiqueCommandeController extends Controller
             ],
         ];
 
+        // Endpoint et auth alignes EXACTEMENT sur le flux reservation qui
+        // fonctionne en prod (ReservationController::createNaboopayCheckoutSession) :
+        // meme /api/v2/transactions, meme withToken(), meme detection multi-cles.
         try {
             $response = Http::acceptJson()
                 ->asJson()
-                ->withHeaders(['Authorization' => 'Bearer ' . $apiKey])
-                ->post(rtrim((string) config('services.naboopay.base_url', 'https://api.naboopay.com/api/v1'), '/') . '/transaction/create-transaction', $payload);
+                ->withToken((string) $apiKey)
+                ->post(rtrim((string) config('services.naboopay.base_url'), '/') . '/api/v2/transactions', $payload);
         } catch (ConnectionException) {
             throw ValidationException::withMessages([
                 'mode_paiement' => 'NabooPay est momentanement injoignable. Reessayez ou choisissez le paiement a la livraison.',
             ]);
         }
 
-        if (! $response->successful()) {
+        if ($response->failed()) {
             Log::error('NabooPay checkout boutique failed', [
                 'status' => $response->status(),
                 'body' => $response->json(),
@@ -302,23 +305,28 @@ class BoutiqueCommandeController extends Controller
             ]);
 
             throw ValidationException::withMessages([
-                'mode_paiement' => 'Le paiement en ligne a echoue. Reessayez ou choisissez le paiement a la livraison.',
+                'mode_paiement' => $response->json('error') ?? 'Le paiement en ligne a echoue. Reessayez ou choisissez le paiement a la livraison.',
             ]);
         }
 
         $body = $response->json();
-        $checkoutUrl = (string) ($body['checkout_url'] ?? '');
-        $orderId = (string) ($body['order_id'] ?? $payload['order_id']);
+        $checkoutUrl = $body['checkout_url']
+            ?? $body['checkoutUrl']
+            ?? $body['checkout_url_payment']
+            ?? $body['payment_url']
+            ?? $body['url']
+            ?? null;
+        $orderId = $body['order_id'] ?? $body['orderId'] ?? $payload['order_id'];
 
-        if ($checkoutUrl === '') {
+        if (! $checkoutUrl || ! $orderId) {
             throw ValidationException::withMessages([
-                'mode_paiement' => 'NabooPay n a pas renvoye de lien de paiement.',
+                'mode_paiement' => 'NabooPay n a pas renvoye de lien de paiement valide.',
             ]);
         }
 
-        $payment->update(['reference' => $orderId]);
+        $payment->update(['reference' => (string) $orderId]);
 
-        return $checkoutUrl;
+        return (string) $checkoutUrl;
     }
 
     private function naboopayReturnSignature(int|string $paymentId): string

--- a/infra/docker/php/docker-entrypoint.sh
+++ b/infra/docker/php/docker-entrypoint.sh
@@ -8,6 +8,13 @@
 
 set -e
 
+# Les volumes nommes (app_storage, app_logs) sont montes par-dessus les
+# dossiers de l'image et demarrent en root : le chown fait au build est
+# ecrase. On le refait ici, au runtime en root, AVANT de passer FPM en
+# www-data. Sans ca : logs muets (root:root) et uploads d'images en echec.
+echo "[entrypoint] Ajustement des droits storage..."
+chown -R www-data:www-data storage bootstrap/cache 2>/dev/null || true
+
 echo "[entrypoint] Génération des caches Laravel..."
 php artisan config:cache
 php artisan route:cache


### PR DESCRIPTION
## Problème
Le paiement en ligne de la boutique échouait en prod (`NabooPay checkout boutique failed {status:405}`).

## Causes
1. **Endpoint NabooPay incorrect** : `/transaction/create-transaction` + header Bearer manuel + `base_url` avec défaut erroné → 405 Method Not Allowed. Le flux réservation (qui marche en prod) utilise `/api/v2/transactions` + `withToken()`.
2. **Droits storage en prod** : les volumes nommés (`app_storage`, `app_logs`) sont montés par-dessus les dossiers de l'image et démarrent en `root` → PHP-FPM (www-data) ne peut ni écrire les logs (erreurs muettes) ni recevoir les uploads d'images.

## Corrections
- `BoutiqueCommandeController` aligné exactement sur `ReservationController::createNaboopayCheckoutSession` (endpoint, auth, détection multi-clés du checkout_url/order_id)
- `chown www-data` des volumes storage ajouté à l'entrypoint (runtime, après montage)

## Déploiement
Après merge : redéployer, puis `migrate` non nécessaire (aucune migration). L'entrypoint corrige les droits automatiquement à chaque démarrage désormais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)