### PR TITLE
feat(boutique): frais de livraison gérés par zone (admin)

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/DeliveryZoneController.php
+++ b/backend/app/Http/Controllers/Api/Admin/DeliveryZoneController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\Api\Admin;
 
+use App\Http\Controllers\Api\Client\BoutiqueController;
 use App\Http\Controllers\Controller;
 use App\Models\DeliveryZone;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class DeliveryZoneController extends Controller
 {
@@ -25,6 +27,7 @@ class DeliveryZoneController extends Controller
         ]);
 
         $zone = DeliveryZone::create($data);
+        $this->clearBoutiqueCache();
         return response()->json(['success' => true, 'data' => $zone], 201);
     }
 
@@ -38,18 +41,27 @@ class DeliveryZoneController extends Controller
         ]);
 
         $deliveryZone->update($data);
+        $this->clearBoutiqueCache();
         return response()->json(['success' => true, 'data' => $deliveryZone]);
     }
 
     public function destroy(DeliveryZone $deliveryZone): JsonResponse
     {
         $deliveryZone->delete();
+        $this->clearBoutiqueCache();
         return response()->json(['success' => true]);
     }
 
     public function toggleStatus(DeliveryZone $deliveryZone): JsonResponse
     {
         $deliveryZone->update(['est_active' => !$deliveryZone->est_active]);
+        $this->clearBoutiqueCache();
         return response()->json(['success' => true, 'data' => $deliveryZone]);
+    }
+
+    /** Les zones sont servies via le catalogue boutique mis en cache. */
+    private function clearBoutiqueCache(): void
+    {
+        Cache::forget(BoutiqueController::CACHE_KEY);
     }
 }

--- a/backend/app/Http/Controllers/Api/Client/BoutiqueCommandeController.php
+++ b/backend/app/Http/Controllers/Api/Client/BoutiqueCommandeController.php
@@ -43,6 +43,7 @@ class BoutiqueCommandeController extends Controller
             'client.telephone' => ['required', 'string', 'max:30'],
             'client.email' => ['nullable', 'email', 'max:255'],
             'mode_livraison' => ['required', 'in:domicile,boutique'],
+            'delivery_zone_id' => ['required_if:mode_livraison,domicile', 'nullable', 'integer', 'exists:delivery_zones,id'],
             'adresse_livraison' => ['required_if:mode_livraison,domicile', 'nullable', 'string', 'max:500'],
             'instructions_livraison' => ['nullable', 'string', 'max:500'],
             'mode_paiement' => ['required', 'in:wave,orange_money,livraison'],
@@ -99,10 +100,27 @@ class BoutiqueCommandeController extends Controller
             ];
         }
 
-        $fraisLivraison = $data['mode_livraison'] === 'boutique' ? 0.0 : 2000.0;
+        // Frais de livraison : zone choisie (retrait boutique = gratuit). Le
+        // prix vient TOUJOURS de la base, jamais du client.
+        $zone = null;
+        $fraisLivraison = 0.0;
+
+        if ($data['mode_livraison'] === 'domicile') {
+            $zone = \App\Models\DeliveryZone::where('est_active', true)
+                ->find($data['delivery_zone_id']);
+
+            if (! $zone) {
+                throw ValidationException::withMessages([
+                    'delivery_zone_id' => 'La zone de livraison choisie n est plus disponible.',
+                ]);
+            }
+
+            $fraisLivraison = (float) $zone->prix;
+        }
+
         $montantTotal = round($sousTotal + $fraisLivraison, 2);
 
-        $result = DB::transaction(function () use ($data, $client, $lignes, $sousTotal, $fraisLivraison, $montantTotal) {
+        $result = DB::transaction(function () use ($data, $client, $lignes, $sousTotal, $fraisLivraison, $montantTotal, $zone) {
             $commande = Commande::create([
                 'numero_commande' => $this->commandes->generateNumeroCommande(),
                 'client_id' => $client->id,
@@ -119,6 +137,8 @@ class BoutiqueCommandeController extends Controller
                 'nom_destinataire' => trim($client->prenom . ' ' . $client->nom),
                 'instructions_livraison' => $data['instructions_livraison'] ?? null,
                 'mode_livraison' => $data['mode_livraison'] === 'boutique' ? 'boutique' : 'domicile',
+                'delivery_zone_id' => $zone?->id,
+                'zone_livraison_nom' => $zone?->nom,
                 'source' => 'site_web',
                 'notes_client' => $data['mode_paiement'] === 'livraison'
                     ? 'Paiement a la livraison choisi par le client.'

--- a/backend/app/Http/Controllers/Api/Client/BoutiqueController.php
+++ b/backend/app/Http/Controllers/Api/Client/BoutiqueController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Client;
 
 use App\Http\Controllers\Controller;
 use App\Models\Category;
+use App\Models\DeliveryZone;
 use App\Models\Produit;
 use App\Support\SystemSettings;
 use Illuminate\Http\JsonResponse;
@@ -80,9 +81,22 @@ class BoutiqueController extends Controller
             ->values()
             ->all();
 
+        $deliveryZones = DeliveryZone::where('est_active', true)
+            ->orderBy('ordre_affichage')
+            ->orderBy('prix')
+            ->get()
+            ->map(fn (DeliveryZone $z) => [
+                'id' => $z->id,
+                'nom' => $z->nom,
+                'prix' => (float) $z->prix,
+            ])
+            ->values()
+            ->all();
+
         return [
             'categories' => $categories,
             'produits' => $produits,
+            'delivery_zones' => $deliveryZones,
             'settings' => [
                 'devise' => SystemSettings::get('devise', 'FCFA'),
                 'telephone_whatsapp' => SystemSettings::get('telephone_whatsapp', '221778153939'),

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -204,6 +204,7 @@ Route::middleware(['auth.token', 'role:admin', 'log.admin'])
             Route::get('stats/commandes', [CommandeController::class, 'getStatistics'])->name('commandes.stats');
 
             // Zones de livraison
+            Route::post('delivery-zones/{deliveryZone}/toggle-status', [DeliveryZoneController::class, 'toggleStatus'])->name('delivery-zones.toggle-status');
             Route::apiResource('delivery-zones', DeliveryZoneController::class);
 
             // Paramètres boutique

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ const EcommerceOverviewPage = lazy(() => import('./features/admin/ecommerce/Ecom
 const ProduitsPage = lazy(() => import('./features/admin/ecommerce/ProduitsPage').then(m => ({ default: m.ProduitsPage })))
 const CategoriesPage = lazy(() => import('./features/admin/ecommerce/CategoriesPage').then(m => ({ default: m.CategoriesPage })))
 const CommandesPage = lazy(() => import('./features/admin/ecommerce/CommandesPage').then(m => ({ default: m.CommandesPage })))
+const EcommerceParametresPage = lazy(() => import('./features/admin/ecommerce/ParametresPage').then(m => ({ default: m.ParametresPage })))
 
 function NotFound() {
   return (
@@ -119,6 +120,7 @@ function App() {
       <Route path="/console-thomas/ecommerce/produits" element={<AdminRoute><ProduitsPage /></AdminRoute>} />
       <Route path="/console-thomas/ecommerce/categories" element={<AdminRoute><CategoriesPage /></AdminRoute>} />
       <Route path="/console-thomas/ecommerce/commandes" element={<AdminRoute><CommandesPage /></AdminRoute>} />
+      <Route path="/console-thomas/ecommerce/parametres" element={<AdminRoute><EcommerceParametresPage /></AdminRoute>} />
       <Route path="/console-thomas/logs" element={<AdminRoute><LogsPage /></AdminRoute>} />
       <Route path="/console-thomas/parametres" element={<AdminRoute><SettingsPage /></AdminRoute>} />
       <Route path="/console-thomas/signalements" element={<AdminRoute><AdminSignalementsPage /></AdminRoute>} />

--- a/frontend/src/features/admin/ecommerce/ParametresPage.tsx
+++ b/frontend/src/features/admin/ecommerce/ParametresPage.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useState } from 'react'
+import { Plus, Truck, Trash2, Edit2, ToggleLeft, ToggleRight, X, AlertTriangle, CheckCircle2, MapPin } from 'lucide-react'
+import { EcommerceLayout } from './components/EcommerceLayout'
+import {
+  getDeliveryZones, createDeliveryZone, updateDeliveryZone,
+  deleteDeliveryZone, toggleDeliveryZoneStatus,
+} from './ecommerce.api'
+import { money } from './components/EcommerceUi'
+import type { DeliveryZone } from './ecommerce.types'
+
+interface ToastItem { id: number; message: string; type: 'success' | 'error' }
+
+interface ZoneForm {
+  nom: string
+  prix: string
+  ordre_affichage: string
+  est_active: boolean
+}
+
+const emptyForm: ZoneForm = { nom: '', prix: '', ordre_affichage: '0', est_active: true }
+
+function Toast({ message, type, onDismiss }: { message: string; type: 'success' | 'error'; onDismiss: () => void }) {
+  return (
+    <div className={`flex items-center gap-3 px-4 py-3 rounded-2xl shadow-lg border text-sm font-medium
+      ${type === 'success' ? 'bg-white border-gray-200 text-gray-900' : 'bg-rose-50 border-rose-200 text-rose-700'}`}>
+      {type === 'success'
+        ? <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0" strokeWidth={1.5} />
+        : <AlertTriangle className="w-4 h-4 text-rose-500 flex-shrink-0" strokeWidth={1.5} />
+      }
+      <span className="flex-1">{message}</span>
+      <button onClick={onDismiss} className="ml-1 p-0.5 rounded hover:opacity-60 transition-opacity">
+        <X className="w-3 h-3" strokeWidth={2} />
+      </button>
+    </div>
+  )
+}
+
+export function ParametresPage() {
+  const [zones, setZones] = useState<DeliveryZone[]>([])
+  const [loading, setLoading] = useState(true)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editing, setEditing] = useState<DeliveryZone | null>(null)
+  const [form, setForm] = useState<ZoneForm>(emptyForm)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<DeliveryZone | null>(null)
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+
+  const addToast = (message: string, type: 'success' | 'error' = 'success') => {
+    const id = Date.now()
+    setToasts(prev => [...prev, { id, message, type }])
+    setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 3500)
+  }
+  const removeToast = (id: number) => setToasts(prev => prev.filter(t => t.id !== id))
+
+  const load = async () => {
+    setLoading(true)
+    try {
+      setZones(await getDeliveryZones())
+    } catch {
+      addToast('Impossible de charger les zones de livraison.', 'error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load() }, [])
+
+  const openCreate = () => {
+    setEditing(null)
+    setForm(emptyForm)
+    setError(null)
+    setModalOpen(true)
+  }
+
+  const openEdit = (zone: DeliveryZone) => {
+    setEditing(zone)
+    setForm({
+      nom: zone.nom,
+      prix: String(zone.prix),
+      ordre_affichage: String(zone.ordre_affichage),
+      est_active: zone.est_active,
+    })
+    setError(null)
+    setModalOpen(true)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!form.nom.trim()) { setError('Le nom de la zone est obligatoire.'); return }
+    setSaving(true)
+    setError(null)
+    try {
+      const payload = {
+        nom: form.nom.trim(),
+        prix: Number(form.prix) || 0,
+        ordre_affichage: Number(form.ordre_affichage) || 0,
+        est_active: form.est_active,
+      }
+      if (editing) {
+        await updateDeliveryZone(editing.id, payload)
+        addToast('Zone modifiée.')
+      } else {
+        await createDeliveryZone(payload)
+        addToast('Zone créée.')
+      }
+      setModalOpen(false)
+      load()
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message
+      setError(msg ?? 'Enregistrement impossible.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleToggle = async (zone: DeliveryZone) => {
+    try {
+      await toggleDeliveryZoneStatus(zone.id)
+      setZones(prev => prev.map(z => z.id === zone.id ? { ...z, est_active: !z.est_active } : z))
+    } catch {
+      addToast('Impossible de changer le statut.', 'error')
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+    try {
+      await deleteDeliveryZone(deleteTarget.id)
+      addToast(`Zone « ${deleteTarget.nom} » supprimée.`)
+      setDeleteTarget(null)
+      load()
+    } catch {
+      addToast('Impossible de supprimer la zone.', 'error')
+    }
+  }
+
+  const inputCls = 'w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#ff5ca5]/40 focus:border-[#ff5ca5] transition-all'
+
+  return (
+    <EcommerceLayout>
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Paramètres de la boutique</h1>
+          <p className="text-sm text-gray-500 mt-1">Gérez les zones et frais de livraison de votre boutique.</p>
+        </div>
+      </div>
+
+      {/* Zones de livraison */}
+      <section className="bg-white rounded-2xl border border-gray-200 shadow-sm">
+        <div className="flex items-center justify-between p-5 border-b border-gray-100">
+          <div className="flex items-center gap-2.5">
+            <div className="w-9 h-9 rounded-xl bg-pink-50 flex items-center justify-center">
+              <Truck className="w-4.5 h-4.5 text-[#e91e63]" strokeWidth={1.5} />
+            </div>
+            <div>
+              <h2 className="text-sm font-bold text-gray-900">Zones de livraison</h2>
+              <p className="text-xs text-gray-500">Chaque zone définit un tarif de livraison à domicile</p>
+            </div>
+          </div>
+          <button onClick={openCreate} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-[#e91e63] text-white text-sm font-semibold hover:bg-[#d81b60] transition-colors">
+            <Plus className="w-3.5 h-3.5" strokeWidth={2.5} />
+            Ajouter une zone
+          </button>
+        </div>
+
+        <div className="p-5">
+          {loading ? (
+            <div className="space-y-2.5">
+              {[1, 2, 3].map(i => <div key={i} className="h-14 bg-gray-100 rounded-xl animate-pulse" />)}
+            </div>
+          ) : zones.length === 0 ? (
+            <div className="py-10 text-center">
+              <MapPin className="w-8 h-8 text-gray-300 mx-auto mb-3" strokeWidth={1.5} />
+              <p className="text-sm font-medium text-gray-900 mb-1">Aucune zone de livraison</p>
+              <p className="text-xs text-gray-500 mb-4">Ajoutez vos quartiers/villes avec leur tarif (ex : Dakar centre 2 000, Banlieue 3 000…)</p>
+              <button onClick={openCreate} className="px-4 py-2 bg-[#e91e63] text-white text-xs font-semibold rounded-xl hover:bg-[#d81b60] transition-colors">
+                + Première zone
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {zones.map(zone => (
+                <div key={zone.id} className="flex items-center gap-4 px-4 py-3 rounded-xl border border-gray-100 hover:bg-gray-50 transition-colors group">
+                  <MapPin className={`w-4 h-4 flex-shrink-0 ${zone.est_active ? 'text-[#e91e63]' : 'text-gray-300'}`} strokeWidth={1.5} />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-gray-900 truncate">{zone.nom}</p>
+                  </div>
+                  <span className="text-sm font-bold text-gray-900">{money(zone.prix)}</span>
+                  <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-semibold ${
+                    zone.est_active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'
+                  }`}>
+                    <span className={`w-1.5 h-1.5 rounded-full ${zone.est_active ? 'bg-green-500' : 'bg-gray-400'}`} />
+                    {zone.est_active ? 'Active' : 'Masquée'}
+                  </span>
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button onClick={() => handleToggle(zone)} className="p-2 rounded-lg hover:bg-gray-100" title={zone.est_active ? 'Désactiver' : 'Activer'}>
+                      {zone.est_active
+                        ? <ToggleRight className="w-4 h-4 text-gray-600" strokeWidth={1.5} />
+                        : <ToggleLeft className="w-4 h-4 text-gray-400" strokeWidth={1.5} />}
+                    </button>
+                    <button onClick={() => openEdit(zone)} className="p-2 rounded-lg hover:bg-gray-100">
+                      <Edit2 className="w-4 h-4 text-gray-600" strokeWidth={1.5} />
+                    </button>
+                    <button onClick={() => setDeleteTarget(zone)} className="p-2 rounded-lg hover:bg-rose-50">
+                      <Trash2 className="w-4 h-4 text-rose-400" strokeWidth={1.5} />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <p className="mt-4 text-xs text-gray-400">
+            💡 Le retrait au salon reste toujours gratuit. Seule la livraison à domicile utilise ces tarifs.
+          </p>
+        </div>
+      </section>
+
+      {/* Modal créer/éditer */}
+      {modalOpen && (
+        <div className="fixed inset-0 bg-black/30 backdrop-blur-[2px] z-50 flex items-center justify-center p-4" onClick={(e) => { if (e.target === e.currentTarget) setModalOpen(false) }}>
+          <div className="bg-white rounded-3xl border border-gray-200 shadow-xl w-full max-w-md">
+            <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-gray-200">
+              <h2 className="font-bold text-gray-900 text-lg">{editing ? 'Modifier la zone' : 'Nouvelle zone de livraison'}</h2>
+              <button onClick={() => setModalOpen(false)} className="p-2 rounded-xl hover:bg-gray-100">
+                <X className="w-4 h-4 text-gray-500" strokeWidth={1.5} />
+              </button>
+            </div>
+            <form onSubmit={handleSubmit} className="p-6 space-y-4">
+              <div>
+                <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Nom de la zone <span className="text-rose-400">*</span></label>
+                <input type="text" value={form.nom} onChange={e => setForm({ ...form, nom: e.target.value })} placeholder="Ex : Dakar centre, Parcelles, Rufisque…" className={inputCls} />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Frais (FCFA)</label>
+                  <input type="number" min="0" step="100" value={form.prix} onChange={e => setForm({ ...form, prix: e.target.value })} placeholder="2000" className={inputCls} />
+                </div>
+                <div>
+                  <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Ordre</label>
+                  <input type="number" min="0" value={form.ordre_affichage} onChange={e => setForm({ ...form, ordre_affichage: e.target.value })} className={inputCls} />
+                </div>
+              </div>
+              <label className="flex items-center justify-between px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl cursor-pointer hover:bg-gray-100 transition-colors">
+                <span className="text-sm font-medium text-gray-900">Zone active (proposée aux clients)</span>
+                <div onClick={() => setForm({ ...form, est_active: !form.est_active })} className={`w-10 h-6 rounded-full transition-colors relative ${form.est_active ? 'bg-[#e91e63]' : 'bg-gray-300'}`}>
+                  <span className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${form.est_active ? 'translate-x-5' : 'translate-x-1'}`} />
+                </div>
+              </label>
+
+              {error && (
+                <div className="flex items-center gap-2.5 px-4 py-3 bg-rose-50 border border-rose-200 rounded-xl">
+                  <AlertTriangle className="w-4 h-4 text-rose-500 flex-shrink-0" strokeWidth={1.5} />
+                  <p className="text-sm text-rose-600">{error}</p>
+                </div>
+              )}
+
+              <div className="flex gap-3 pt-2">
+                <button type="button" onClick={() => setModalOpen(false)} className="flex-1 py-3 rounded-xl border border-gray-200 text-sm font-semibold text-gray-500 hover:bg-gray-100 transition-colors">Annuler</button>
+                <button type="submit" disabled={saving} className="flex-1 py-3 rounded-xl bg-[#e91e63] text-white text-sm font-semibold hover:bg-[#d81b60] transition-colors disabled:opacity-50">
+                  {saving ? 'Enregistrement…' : editing ? 'Enregistrer' : 'Créer'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Confirmation suppression */}
+      {deleteTarget && (
+        <div className="fixed inset-0 bg-black/30 backdrop-blur-[2px] z-50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-3xl border border-gray-200 shadow-xl w-full max-w-sm p-6">
+            <div className="w-12 h-12 bg-rose-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
+              <Trash2 className="w-5 h-5 text-rose-500" strokeWidth={1.5} />
+            </div>
+            <h3 className="font-bold text-gray-900 text-center mb-1">Supprimer la zone ?</h3>
+            <p className="text-sm text-gray-500 text-center mb-5">« {deleteTarget.nom} » sera supprimée. Les commandes déjà passées ne sont pas affectées.</p>
+            <div className="flex gap-3">
+              <button onClick={() => setDeleteTarget(null)} className="flex-1 py-2.5 rounded-xl border border-gray-200 text-sm font-semibold text-gray-500 hover:bg-gray-100 transition-colors">Annuler</button>
+              <button onClick={handleDelete} className="flex-1 py-2.5 rounded-xl bg-rose-500 text-white text-sm font-semibold hover:bg-rose-600 transition-colors">Supprimer</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Toasts */}
+      <div className="fixed bottom-6 right-6 flex flex-col gap-2 z-[200] min-w-[280px] max-w-[360px]">
+        {toasts.map(t => <Toast key={t.id} message={t.message} type={t.type} onDismiss={() => removeToast(t.id)} />)}
+      </div>
+    </EcommerceLayout>
+  )
+}

--- a/frontend/src/features/admin/ecommerce/components/EcommerceLayout.tsx
+++ b/frontend/src/features/admin/ecommerce/components/EcommerceLayout.tsx
@@ -11,6 +11,7 @@ const tabs = [
   { label: 'Produits', path: '/console-thomas/ecommerce/produits' },
   { label: 'Catégories', path: '/console-thomas/ecommerce/categories' },
   { label: 'Commandes', path: '/console-thomas/ecommerce/commandes' },
+  { label: 'Paramètres', path: '/console-thomas/ecommerce/parametres' },
 ]
 
 export function EcommerceLayout({ children }: EcommerceLayoutProps) {

--- a/frontend/src/features/admin/ecommerce/ecommerce.api.ts
+++ b/frontend/src/features/admin/ecommerce/ecommerce.api.ts
@@ -264,6 +264,11 @@ export async function updateDeliveryZone(id: number, payload: any) {
   return data.data
 }
 
+export async function toggleDeliveryZoneStatus(id: number) {
+  const { data } = await apiClient.post<ApiEnvelope<DeliveryZone>>(`${BASE}/delivery-zones/${id}/toggle-status`, {})
+  return data.data
+}
+
 export async function deleteDeliveryZone(id: number) {
   await apiClient.delete(`${BASE}/delivery-zones/${id}`)
 }

--- a/frontend/src/features/admin/ecommerce/ecommerce.types.ts
+++ b/frontend/src/features/admin/ecommerce/ecommerce.types.ts
@@ -238,8 +238,12 @@ export interface KPIStats {
 
 export interface DeliveryZone {
   id: number
-  nom?: string
-  [key: string]: unknown
+  nom: string
+  prix: number
+  est_active: boolean
+  ordre_affichage: number
+  created_at?: string
+  updated_at?: string
 }
 
 // ============= ENVELOPPES API =============

--- a/frontend/src/features/client/boutique/CommanderPage.tsx
+++ b/frontend/src/features/client/boutique/CommanderPage.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Loader2, Lock, MapPin, ShieldCheck, ShoppingBag, Store, Truck } from 'lucide-react'
 import { createBoutiqueCommande, getClientBoutique } from '../client.api'
+import type { ClientDeliveryZone } from '../client.types'
 import { BoutiqueHeader } from './BoutiqueHeader'
 import { clearPanier, panierTotal, usePanier } from './panier'
-
-const FRAIS_LIVRAISON = 2000
 
 type ModePaiement = 'wave' | 'orange_money' | 'livraison'
 
@@ -13,12 +12,14 @@ type ModePaiement = 'wave' | 'orange_money' | 'livraison'
 export function CommanderPage() {
   const items = usePanier()
   const [devise, setDevise] = useState('FCFA')
+  const [zones, setZones] = useState<ClientDeliveryZone[]>([])
 
   const [prenom, setPrenom] = useState('')
   const [nom, setNom] = useState('')
   const [telephone, setTelephone] = useState('')
   const [email, setEmail] = useState('')
   const [modeLivraison, setModeLivraison] = useState<'domicile' | 'boutique'>('domicile')
+  const [zoneId, setZoneId] = useState<number | null>(null)
   const [adresse, setAdresse] = useState('')
   const [instructions, setInstructions] = useState('')
   const [modePaiement, setModePaiement] = useState<ModePaiement>('wave')
@@ -28,20 +29,26 @@ export function CommanderPage() {
 
   useEffect(() => {
     getClientBoutique()
-      .then((data) => setDevise(data.settings.devise))
+      .then((data) => {
+        setDevise(data.settings.devise)
+        setZones(data.delivery_zones)
+        if (data.delivery_zones.length > 0) setZoneId(data.delivery_zones[0].id)
+      })
       .catch(() => { /* devise par defaut */ })
   }, [])
 
+  const selectedZone = useMemo(() => zones.find((z) => z.id === zoneId) ?? null, [zones, zoneId])
+
   const sousTotal = panierTotal(items)
-  const frais = modeLivraison === 'boutique' ? 0 : FRAIS_LIVRAISON
+  const frais = modeLivraison === 'boutique' ? 0 : (selectedZone?.prix ?? 0)
   const total = sousTotal + frais
 
   const formValide = useMemo(() =>
     prenom.trim() !== '' &&
     nom.trim() !== '' &&
     telephone.replace(/\D/g, '').length >= 9 &&
-    (modeLivraison === 'boutique' || adresse.trim() !== ''),
-  [prenom, nom, telephone, modeLivraison, adresse])
+    (modeLivraison === 'boutique' || (adresse.trim() !== '' && zoneId !== null)),
+  [prenom, nom, telephone, modeLivraison, adresse, zoneId])
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
@@ -58,6 +65,7 @@ export function CommanderPage() {
           email: email.trim() || null,
         },
         mode_livraison: modeLivraison,
+        delivery_zone_id: modeLivraison === 'domicile' ? zoneId : null,
         adresse_livraison: modeLivraison === 'domicile' ? adresse.trim() : null,
         instructions_livraison: instructions.trim() || null,
         mode_paiement: modePaiement,
@@ -147,8 +155,8 @@ export function CommanderPage() {
                 >
                   <Truck className={`h-5 w-5 shrink-0 ${modeLivraison === 'domicile' ? 'text-[#f31976]' : 'text-slate-400'}`} />
                   <span>
-                    <span className="block text-sm font-black text-slate-950">Livraison à Dakar</span>
-                    <span className="block text-xs font-semibold text-slate-500">{FRAIS_LIVRAISON.toLocaleString('fr-FR')} {devise}</span>
+                    <span className="block text-sm font-black text-slate-950">Livraison à domicile</span>
+                    <span className="block text-xs font-semibold text-slate-500">Tarif selon votre zone</span>
                   </span>
                 </button>
                 <button
@@ -168,12 +176,35 @@ export function CommanderPage() {
 
               {modeLivraison === 'domicile' ? (
                 <div className="mt-3 space-y-3">
+                  {/* Zone de livraison (definit le tarif) */}
+                  {zones.length > 0 ? (
+                    <div>
+                      <label className="mb-1.5 block text-[11px] font-black uppercase tracking-[0.16em] text-slate-500">
+                        Zone de livraison *
+                      </label>
+                      <select
+                        value={zoneId ?? ''}
+                        onChange={(e) => setZoneId(Number(e.target.value) || null)}
+                        className={inputCls}
+                      >
+                        {zones.map((zone) => (
+                          <option key={zone.id} value={zone.id}>
+                            {zone.nom} — {Math.round(zone.prix).toLocaleString('fr-FR')} {devise}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  ) : (
+                    <p className="bg-amber-50 px-4 py-3 text-xs font-bold text-amber-700">
+                      Aucune zone de livraison configurée. Choisissez le retrait au salon, ou contactez-nous sur WhatsApp.
+                    </p>
+                  )}
                   <div className="relative">
                     <MapPin className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
                     <input
                       value={adresse}
                       onChange={(e) => setAdresse(e.target.value)}
-                      placeholder="Adresse de livraison (quartier, rue, repère) *"
+                      placeholder="Adresse précise (rue, immeuble, repère) *"
                       className={`${inputCls} pl-10`}
                     />
                   </div>
@@ -268,8 +299,8 @@ export function CommanderPage() {
                   <span>{Math.round(sousTotal).toLocaleString('fr-FR')} {devise}</span>
                 </div>
                 <div className="flex justify-between text-slate-500">
-                  <span>Livraison</span>
-                  <span>{frais === 0 ? 'Gratuit' : `${frais.toLocaleString('fr-FR')} ${devise}`}</span>
+                  <span>{modeLivraison === 'boutique' ? 'Retrait salon' : selectedZone ? `Livraison — ${selectedZone.nom}` : 'Livraison'}</span>
+                  <span>{frais === 0 ? 'Gratuit' : `${Math.round(frais).toLocaleString('fr-FR')} ${devise}`}</span>
                 </div>
                 <div className="flex justify-between pt-1.5 text-base font-black text-slate-950">
                   <span>Total</span>

--- a/frontend/src/features/client/boutique/PanierPage.tsx
+++ b/frontend/src/features/client/boutique/PanierPage.tsx
@@ -106,7 +106,7 @@ export function PanierPage() {
                 <span className="text-slate-950">{Math.round(total).toLocaleString('fr-FR')} {devise}</span>
               </div>
               <p className="mt-1.5 text-xs font-semibold text-slate-400">
-                Livraison à Dakar : 2 000 {devise} — offerte en retrait au salon. Calculée à l'étape suivante.
+                Frais de livraison calculés selon votre zone à l'étape suivante — gratuits en retrait au salon.
               </p>
 
               <a

--- a/frontend/src/features/client/client.api.ts
+++ b/frontend/src/features/client/client.api.ts
@@ -91,6 +91,7 @@ export async function getClientBoutique() {
     ...data,
     categories: data.categories.map((c) => ({ ...c, image: apiAssetUrl(c.image) })),
     produits: data.produits.map(normalizeClientProduit),
+    delivery_zones: data.delivery_zones ?? [],
   }
 }
 
@@ -111,6 +112,7 @@ export async function getClientProduitDetail(slug: string) {
 export type BoutiqueCommandePayload = {
   client: { prenom: string; nom: string; telephone: string; email: string | null }
   mode_livraison: 'domicile' | 'boutique'
+  delivery_zone_id: number | null
   adresse_livraison: string | null
   instructions_livraison: string | null
   mode_paiement: 'wave' | 'orange_money' | 'livraison'

--- a/frontend/src/features/client/client.types.ts
+++ b/frontend/src/features/client/client.types.ts
@@ -337,9 +337,16 @@ export type ClientProduitDetail = ClientProduit & {
   avis: ClientProduitAvis[]
 }
 
+export type ClientDeliveryZone = {
+  id: number
+  nom: string
+  prix: number
+}
+
 export type ClientBoutique = {
   categories: ClientBoutiqueCategorie[]
   produits: ClientProduit[]
+  delivery_zones: ClientDeliveryZone[]
   settings: {
     devise: string
     telephone_whatsapp: string


### PR DESCRIPTION
## Ce que ça change
Le frais de livraison de 2 000 FCFA était **codé en dur**. Il est maintenant **géré par zone** depuis l'admin.

## Admin — nouvel onglet « Paramètres »
`/console-thomas/ecommerce/parametres` : CRUD des zones de livraison (nom, prix, ordre, actif/masqué). Ex : *Dakar centre 2 000*, *Banlieue 3 000*, *Rufisque 4 000*…

## Côté client
- La boutique publique expose les zones actives
- Au checkout, « Livraison à domicile » affiche un **sélecteur de zone** qui définit le frais ; le récap et le total se mettent à jour en direct
- Retrait au salon reste **gratuit**
- Le prix vient **toujours de la zone en base** (jamais du client) ; la commande stocke `delivery_zone_id` + `zone_livraison_nom`

## Sécurité / cohérence
- `delivery_zone_id` validé côté serveur (zone active existante)
- Cache boutique invalidé à chaque modif de zone

## Test local
Zones 2 000 / 3 000 créées → commande zone Banlieue → frais **3 000** appliqué et stocké correctement.

## Déploiement
Après merge : redéployer. **Aucune migration** (la table `delivery_zones` existe déjà). Créer les zones réelles du salon dans l'admin après déploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)