### PR TITLE
fix(boutique): email réservation parasite + crash détail commande admin

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/CommandeController.php
+++ b/backend/app/Http/Controllers/Api/Admin/CommandeController.php
@@ -463,6 +463,7 @@ class CommandeController extends Controller
             'code_promo' => $commande->code_promo,
             'sous_total' => $commande->sous_total,
             'frais_livraison' => $commande->frais_livraison,
+            'zone_livraison_nom' => $commande->zone_livraison_nom,
             'remise' => $commande->remise,
             'source' => $commande->source,
             

--- a/backend/app/Http/Controllers/Api/Client/PaymentController.php
+++ b/backend/app/Http/Controllers/Api/Client/PaymentController.php
@@ -154,10 +154,15 @@ class PaymentController extends Controller
         }
 
         if ($payment->statut === 'valide') {
-            SendPaymentReceiptNotifications::dispatch($payment->id);
+            // Recu reservation uniquement (pas pour une commande boutique).
+            if ($payment->reservation_id) {
+                SendPaymentReceiptNotifications::dispatch($payment->id);
+            }
 
             return response()->json([
-                'message' => 'Paiement NabooPay valide. Votre reservation est securisee.',
+                'message' => $payment->commande_id
+                    ? 'Paiement valide. Votre commande est confirmee.'
+                    : 'Paiement NabooPay valide. Votre reservation est securisee.',
                 'data' => $payment->fresh(['reservation.client', 'client']),
             ]);
         }
@@ -174,7 +179,9 @@ class PaymentController extends Controller
         $this->markPaymentAsPaid($payment, (string) ($transaction['order_id'] ?? $payment->reference));
 
         return response()->json([
-            'message' => 'Paiement NabooPay valide. Votre reservation est securisee.',
+            'message' => $payment->commande_id
+                ? 'Paiement valide. Votre commande est confirmee.'
+                : 'Paiement NabooPay valide. Votre reservation est securisee.',
             'data' => $payment->fresh(['reservation.client', 'client']),
         ]);
     }
@@ -461,15 +468,22 @@ class PaymentController extends Controller
         $payment->refresh();
         $this->syncReservationPaymentState($payment->reservation_id);
         $this->syncCommandePaymentState($payment->commande_id);
-        // Notif asynchrone (I6) : la requete webhook Stripe/PayTech repond
-        // immediatement (~50 ms au lieu de 1-5 s avec les appels HTTP
-        // Twilio/WhatsApp/Mail synchrones). Un worker queue:work consomme
-        // la queue Redis et envoie le recu en arriere-plan.
-        SendPaymentReceiptNotifications::dispatch($payment->id);
-        // Magic link (Phase 5 etape 2) : lien de session 90j envoye par WhatsApp
-        // apres chaque paiement confirme. Si WhatsApp n est pas configure, le
-        // job log un warning et sort proprement (pas d exception).
-        SendMagicLinkNotification::dispatch($payment->id);
+
+        // Les notifications ci-dessous sont specifiques aux RESERVATIONS
+        // (recu de reservation + magic link de session salon). Un paiement
+        // de commande boutique (commande_id, pas de reservation_id) ne doit
+        // PAS declencher un email de reservation.
+        if ($payment->reservation_id) {
+            // Notif asynchrone (I6) : la requete webhook Stripe/PayTech repond
+            // immediatement (~50 ms au lieu de 1-5 s avec les appels HTTP
+            // Twilio/WhatsApp/Mail synchrones). Un worker queue:work consomme
+            // la queue Redis et envoie le recu en arriere-plan.
+            SendPaymentReceiptNotifications::dispatch($payment->id);
+            // Magic link (Phase 5 etape 2) : lien de session 90j envoye par WhatsApp
+            // apres chaque paiement confirme. Si WhatsApp n est pas configure, le
+            // job log un warning et sort proprement (pas d exception).
+            SendMagicLinkNotification::dispatch($payment->id);
+        }
     }
 
     /**

--- a/backend/app/Models/Client.php
+++ b/backend/app/Models/Client.php
@@ -41,6 +41,17 @@ class Client extends Model
     }
 
     /**
+     * Mesures de couture du client (module confection sur mesure).
+     * Optionnel : la plupart des clients boutique n'en ont pas.
+     *
+     * @return HasOne<MesureClient, $this>
+     */
+    public function mesures(): HasOne
+    {
+        return $this->hasOne(MesureClient::class);
+    }
+
+    /**
      * @return HasMany<ListeNoireClient, $this>
      */
     public function listeNoire(): HasMany


### PR DESCRIPTION
## Deux bugs corrigés
Les commandes boutique réutilisent le circuit de paiement des réservations, ce qui provoquait deux effets de bord.

### 1. Email de réservation reçu après un paiement de produit
`markPaymentAsPaid` (et les retours PayTech/NabooPay déjà validés) envoyaient le reçu de **réservation** + le magic link salon pour **tout** paiement. → Conditionnés à `reservation_id` : une commande boutique ne déclenche plus d'email de réservation. Messages de retour adaptés ("Votre commande est confirmée" vs "Votre réservation est sécurisée").

### 2. « Erreur lors de la récupération de la commande » dans l'admin
Le détail chargeait `client.mesures`, mais cette relation n'était pas définie sur le modèle `Client` du salon (table importée sans la relation) → `Call to undefined relationship [mesures]`. → Relation `mesures()` (hasOne MesureClient) ajoutée. Le détail se charge ; les champs couture restent vides pour les clients boutique. **Bonus** : la zone de livraison est affichée dans le détail.

## Test
Détail commande boutique → OK (`success: true`). Tests auth verts (16 passed).

## Déploiement
Après merge : redéployer. Aucune migration.

⚠️ Note : à terme, un vrai reçu de commande boutique (email/WhatsApp) pourra être ajouté — pour l'instant on supprime juste l'email erroné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)